### PR TITLE
Fixed a bug where solo aspect wasn't correctly parsed

### DIFF
--- a/src/item/filter.py
+++ b/src/item/filter.py
@@ -111,7 +111,7 @@ def should_keep(item: Item):
     if item.aspect and filter_aspects is not None:
         for filter_data in filter_aspects:
             filter_aspect = [filter_data] if isinstance(filter_data, str) else filter_data
-            aspect_name, *rest = aspect if isinstance(filter_aspect, list) else [filter_aspect]
+            aspect_name, *rest = filter_aspect if isinstance(filter_aspect, list) else [filter_aspect]
             threshold = rest[0] if rest else None
             condition = rest[1] if len(rest) > 1 else "larger"
 

--- a/src/item/filter.py
+++ b/src/item/filter.py
@@ -110,8 +110,7 @@ def should_keep(item: Item):
 
     if item.aspect and filter_aspects is not None:
         for filter_data in filter_aspects:
-            filter_aspect = [filter_data] if isinstance(filter_data, str) else filter_data
-            aspect_name, *rest = filter_aspect if isinstance(filter_aspect, list) else [filter_aspect]
+            aspect_name, *rest = filter_data if isinstance(filter_data, list) else [filter_data]
             threshold = rest[0] if rest else None
             condition = rest[1] if len(rest) > 1 else "larger"
 


### PR DESCRIPTION
When the `filter_data` is just a string, then the `filter_aspect` on the next line was a list and would assign `aspect` (which has to be a global of some sort I guess, or a literal) instead of the `filter_aspect`. The result was that it wouldn't pick up aspects.

In general, the two lines that array-ify the `filter_data` seems superfluous, one should be enough (if not an array, wrap in an array)?