### PR TITLE
Adjust aspect value based on the item type

### DIFF
--- a/src/item/read_descr.py
+++ b/src/item/read_descr.py
@@ -250,6 +250,13 @@ def read_descr(rarity: ItemRarity, img_item_descr: np.ndarray) -> Item:
             idx = 0
         found_value = _find_number(concatenated_str, idx)
 
+        # Scale the aspect down to the canonical range if found on an item that scales it up
+        if item.type is ItemType.Amulet:
+            found_value /= 1.5
+        # Possibly add Bow and Crossbow if those scale it up as well
+        if item.type in [ItemType.Axe2H, ItemType.Sword2H, ItemType.Mace2H, ItemType.Scythe, ItemType.Polearm, ItemType.Staff]:
+            found_value /= 2
+
         if found_key is not None:
             item.aspect = Aspect(found_key, found_value, concatenated_str)
         else:

--- a/src/item/read_descr.py
+++ b/src/item/read_descr.py
@@ -254,7 +254,16 @@ def read_descr(rarity: ItemRarity, img_item_descr: np.ndarray) -> Item:
         if item.type is ItemType.Amulet:
             found_value /= 1.5
         # Possibly add Bow and Crossbow if those scale it up as well
-        if item.type in [ItemType.Bow, ItemType.Crossbow, ItemType.Axe2H, ItemType.Sword2H, ItemType.Mace2H, ItemType.Scythe, ItemType.Polearm, ItemType.Staff]:
+        if item.type in [
+            ItemType.Bow,
+            ItemType.Crossbow,
+            ItemType.Axe2H,
+            ItemType.Sword2H,
+            ItemType.Mace2H,
+            ItemType.Scythe,
+            ItemType.Polearm,
+            ItemType.Staff,
+        ]:
             found_value /= 2
 
         if found_key is not None:

--- a/test/item/read_descr_test.py
+++ b/test/item/read_descr_test.py
@@ -41,7 +41,7 @@ BASE_PATH = "test/assets/item"
                 ItemRarity.Legendary,
                 ItemType.Amulet,
                 894,
-                Aspect("frostbitten_aspect", 33),
+                Aspect("frostbitten_aspect", 22),
                 [
                     Affix("strength", 5.5),
                     Affix("imbuement_skill_damage", 28),


### PR DESCRIPTION
The current version reads the aspect variable value as is.

But those values are scaled by 1.5x for Amules and by 2x for two handed weapons.
I propose to scale them back down to the "canonical" values.

(I am not running Rogue, so I don't know whether Bows and Crossbows scale to 2x as well, please adjust accordingly)