### PR TITLE
hidden overlay

### DIFF
--- a/config/params.ini
+++ b/config/params.ini
@@ -1,6 +1,8 @@
 [general]
 ; How many tabs should be checked for items in chest. Note: All 5 Tabs must be unlocked!
 check_chest_tabs=2
+; Transparancy of the overlay when not hovering it (has a 3 second dealy after hovering)
+hidden_transparency=0.35
 ; Which additional scripts should be run. Seperated by comma
 ; Currently available:
 ;   1920x1080: rogue_tb

--- a/config/params.ini
+++ b/config/params.ini
@@ -1,7 +1,7 @@
 [general]
 ; How many tabs should be checked for items in chest. Note: All 5 Tabs must be unlocked!
 check_chest_tabs=2
-; Transparancy of the overlay when not hovering it (has a 3 second dealy after hovering)
+; Transparancy of the overlay when not hovering it (has a 3 second dealy after hovering); The "shown" transparncy is 0.89
 hidden_transparency=0.35
 ; Which additional scripts should be run. Seperated by comma
 ; Currently available:

--- a/src/config.py
+++ b/src/config.py
@@ -73,6 +73,7 @@ class Config:
         self.general = {
             "check_chest_tabs": int(self._select_val("general", "check_chest_tabs")),
             "run_scripts": run_scripts_str.split(",") if run_scripts_str else [],
+            "hidden_transparency": max(0.01, float(self._select_val("general", "hidden_transparency"))),
         }
 
         for key in self.configs["params"]["parser"]["char"]:

--- a/src/overlay.py
+++ b/src/overlay.py
@@ -30,7 +30,8 @@ class Overlay:
         self.is_minimized = True
         self.root = tk.Tk()
         self.root.title("LootFilter Overlay")
-        self.root.attributes("-alpha", 0.89)
+        self.root.attributes("-alpha", 0.87)
+        self.hide_id = self.root.after(15000, lambda: self.root.attributes("-alpha", Config().general["hidden_transparency"]))
         self.root.overrideredirect(True)
         # self.root.wm_attributes("-transparentcolor", "white")
         self.root.wm_attributes("-topmost", True)
@@ -49,6 +50,8 @@ class Overlay:
             f"{self.initial_width}x{self.initial_height}+{self.screen_width//2 - self.initial_width//2 + self.screen_off_x}+{self.screen_height - self.initial_height + self.screen_off_y}"
         )
         self.canvas.pack()
+        self.root.bind("<Enter>", self.show_canvas)
+        self.root.bind("<Leave>", self.hide_canvas)
 
         self.toggle_button = tk.Button(
             self.root,
@@ -108,6 +111,21 @@ class Overlay:
         listbox_handler = ListboxHandler(self.terminal_listbox)
         listbox_handler.setLevel(Logger._logger_level)
         Logger.logger.addHandler(listbox_handler)
+
+    def show_canvas(self, event):
+        # Cancel the pending hide if it exists
+        if self.hide_id:
+            self.root.after_cancel(self.hide_id)
+            self.hide_id = None
+        # Make the window visible
+        self.root.attributes("-alpha", 0.89)
+
+    def hide_canvas(self, event):
+        # Reset the hide timer
+        if self.is_minimized:
+            if self.hide_id is not None:
+                self.root.after_cancel(self.hide_id)
+            self.hide_id = self.root.after(3000, lambda: self.root.attributes("-alpha", Config().general["hidden_transparency"]))
 
     def toggle_size(self):
         if not self.is_minimized:


### PR DESCRIPTION
Make overlay transparent after 3 seconds not hovering it (only when minized). Transparancy can be adjusted in the settings. Choose 0 if it should be hidden completely.