### PR TITLE
UTF8 instead of CP1252 encoding

### DIFF
--- a/src/item/filter.py
+++ b/src/item/filter.py
@@ -86,7 +86,7 @@ class Filter:
                 continue
 
             self.all_file_pathes.append(profile_path)
-            with open(profile_path) as f:
+            with open(profile_path, encoding="utf-8") as f:
                 try:
                     config = yaml.safe_load(f)
                 except yaml.YAMLError as e:


### PR DESCRIPTION
Bug reported in Discord when trying to load profiles that include ASCII art.
'charmap' codec can't decode byte 0x90 in position 461: character maps to \<undefined>

By commenting out the error handling I can see that the code tries to parse the YAML as CP1252.

Traceback (most recent call last):
  File "C:\Tools\d4lf\source\d4lf\src\main.py", line 67, in <module>
    main()
  File "C:\Tools\d4lf\source\d4lf\src\main.py", line 44, in main
    Filter().load_files()
  File "C:\Tools\d4lf\source\d4lf\src\item\filter.py", line 92, in load_files
    config = yaml.safe_load(f)
             ^^^^^^^^^^^^^^^^^
  File "C:\Users\xenpie\miniconda3\envs\d4lf\Lib\site-packages\yaml\__init__.py", line 125, in safe_load
    return load(stream, SafeLoader)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xenpie\miniconda3\envs\d4lf\Lib\site-packages\yaml\__init__.py", line 79, in load
    loader = Loader(stream)
             ^^^^^^^^^^^^^^
  File "C:\Users\xenpie\miniconda3\envs\d4lf\Lib\site-packages\yaml\loader.py", line 34, in __init__
    Reader.__init__(self, stream)
  File "C:\Users\xenpie\miniconda3\envs\d4lf\Lib\site-packages\yaml\reader.py", line 85, in __init__
    self.determine_encoding()
  File "C:\Users\xenpie\miniconda3\envs\d4lf\Lib\site-packages\yaml\reader.py", line 124, in determine_encoding
    self.update_raw()
  File "C:\Users\xenpie\miniconda3\envs\d4lf\Lib\site-packages\yaml\reader.py", line 178, in update_raw
    data = self.stream.read(size)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xenpie\miniconda3\envs\d4lf\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 461: character maps to \<undefined>
Press Enter to exit ...

For me the error is fixed by simply specifying UTF8 encoding in the open() call.
Not sure if this might cause any issues but all my other profiles which do not use ASCII art also still load successfully.