### PR TITLE
Support all resolutions

### DIFF
--- a/src/cam.py
+++ b/src/cam.py
@@ -1,15 +1,15 @@
 import mss.windows
 
+from config.ui import ResManager
+
 mss.windows.CAPTUREBLT = 0
 
 import numpy as np
-import sys
 import threading
 from mss import mss
 import time
 from utils.misc import wait, convert_args_to_numpy
 from logger import Logger
-from config.ui import ResManager
 
 cached_img_lock = threading.Lock()
 
@@ -43,9 +43,6 @@ class Cam:
         self.res_key = f"{width}x{height}"
         self.res_p = f"{height}p"
         Logger.info(f"Found Window Res: {self.res_key}")
-        if self.res_key not in ResManager().transformers.keys():
-            Logger.error(f"The resolution: {self.res_key} is not supported.")
-            sys.exit(0)
 
         self.window_roi["top"] = offset_y
         self.window_roi["left"] = offset_x
@@ -60,6 +57,9 @@ class Cam:
             self.window_roi["top"] + self.window_roi["height"] - 10,
         )
         self.window_offset_set = True
+        ResManager().set_resolution(self.res_key)
+        if self.window_roi["width"] / self.window_roi["height"] < 16 / 10:
+            Logger.warning("Aspect ratio is too narrow, please use a wider window. At least 16/10")
 
     def is_offset_set(self):
         return self.window_offset_set

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -24,7 +24,7 @@ class IniConfigLoader:
 
     def __load_params(self):
         parser = configparser.ConfigParser()
-        if (p := (Path(USER_DIR) / CONFIG_IN_USER_DIR / PARAMS_INI)).exists():
+        if (p := (Path(USER_DIR) / CONFIG_IN_USER_DIR / PARAMS_INI)).exists() and p.stat().st_size:
             parser.read(p)
         else:
             parser.read(self._config_path / PARAMS_INI)

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -40,7 +40,7 @@ class IniConfigLoader:
         self._parsers["params"].read(self._config_path / PARAMS_INI)
         if (p := (Path(USER_DIR) / CONFIG_IN_USER_DIR / PARAMS_INI)).exists() and p.stat().st_size:
             self._parsers["custom"].read(p)
-  
+
         self._advanced_options = AdvancedOptions(
             run_scripts=self._select_val("advanced_options", "run_scripts"),
             run_filter=self._select_val("advanced_options", "run_filter"),

--- a/src/config/ui.py
+++ b/src/config/ui.py
@@ -1,6 +1,6 @@
 import logging
 
-from numpy import array, ndarray
+import numpy as np
 
 from config.helper import singleton
 from config.models import UiRoi, UiPos, UiOffsets, Colors, HSVRange
@@ -8,6 +8,7 @@ from config.models import UiRoi, UiPos, UiOffsets, Colors, HSVRange
 LOGGER = logging.getLogger("d4lf")
 
 _FHD = (
+    (1920, 1080),
     UiOffsets(
         find_bullet_points_width=39,
         find_seperator_short_offset_top=250,
@@ -36,46 +37,55 @@ _FHD = (
         window_dimensions=(1920, 1080),
     ),
     UiRoi(
-        core_skill=array([1094, 981, 47, 47]),
-        health_slice=array([587, 925, 43, 130]),
-        hud_detection=array([702, 978, 59, 53]),
-        mini_map_visible=array([1719, 123, 60, 60]),
-        rel_descr_search_left=array([-455, 0, 60, 880]),
-        rel_descr_search_right=array([30, 0, 60, 880]),
-        rel_fav_flag=array([4, 3, 8, 10]),
-        rel_skill_cd=array([6, 4, 22, 12]),
-        skill3=array([904, 981, 49, 49]),
-        skill4=array([967, 981, 47, 47]),
-        slots_3x11=array([1268, 722, 607, 243]),
-        slots_5x10=array([46, 269, 612, 486]),
-        sort_icon=array([1220, 666, 63, 62]),
-        stash_menu_icon=array([296, 72, 109, 48]),
-        tab_slots_6=array([150, 142, 400, 51]),
-        vendor_text=array([100, 391, 94, 22]),
+        core_skill=np.array([1094, 981, 47, 47]),
+        health_slice=np.array([587, 925, 43, 130]),
+        hud_detection=np.array([702, 978, 59, 53]),
+        mini_map_visible=np.array([1719, 123, 60, 60]),
+        rel_descr_search_left=np.array([-455, 0, 60, 880]),
+        rel_descr_search_right=np.array([30, 0, 60, 880]),
+        rel_fav_flag=np.array([4, 3, 8, 10]),
+        rel_skill_cd=np.array([6, 4, 22, 12]),
+        skill3=np.array([904, 981, 49, 49]),
+        skill4=np.array([967, 981, 47, 47]),
+        slots_3x11=np.array([1268, 722, 607, 243]),
+        slots_5x10=np.array([46, 269, 612, 486]),
+        sort_icon=np.array([1220, 666, 63, 62]),
+        stash_menu_icon=np.array([296, 72, 109, 48]),
+        tab_slots_6=np.array([150, 142, 400, 51]),
+        vendor_text=np.array([100, 391, 94, 22]),
     ),
 )
 
 
 class _ResTransformer:
-    def __init__(self, factor: float = 1, width: int | None = None, black_bars: tuple[int, int] | None = None):
-        self.factor = factor
-        self.width = width
-        self.black_bars = black_bars
+    def __init__(self, resolution: str):
+        self._target_width, self._target_height = map(int, resolution.split("x"))
+        self._scale_x = self._target_width / _FHD[0][0]
+        self._scale_y = self._target_height / _FHD[0][1]
+        self._highest_ratio = 27 / 9
 
     def __transform(self, value: int) -> int:
-        return int(value * self.factor)
+        return int(value * self._scale_y)
 
-    def __transform_array(self, value: ndarray, scaly_only=False) -> ndarray:
-        scaled_value = value * self.factor
-        if self.width is not None and not scaly_only:
-            width_org = int(self.factor * 1920)
-            is_right_side = scaled_value[0] > width_org / 2
-            if is_right_side:
-                scaled_value[0] += self.width - width_org
-            if self.black_bars is not None:
-                offset = self.black_bars[1] if is_right_side else self.black_bars[0]
-                scaled_value[0] += offset
-        return scaled_value.astype(int)
+    def __transform_array(self, value: np.ndarray, scale_only=False) -> np.ndarray:
+        new_value = value * self._scale_y
+        if scale_only:
+            return new_value.astype(int)
+
+        # handle widescreen stretching
+        width_org = int(self._scale_y * _FHD[0][0])
+        is_right_side = new_value[0] > width_org / 2
+        if is_right_side:
+            new_value[0] += self._target_width - width_org
+
+        # handle black bars
+        aspect_ratio = self._target_width / self._target_height
+        if aspect_ratio > self._highest_ratio:
+            new_width = int(self._target_height * self._highest_ratio)
+            black_bar = (self._target_width - new_width) // 2
+            new_value[0] = new_value[0] - black_bar if is_right_side else new_value[0] + black_bar
+
+        return new_value.astype(int)
 
     def __transform_list_of_tuples(self, value: list[tuple[int, int]]) -> list[tuple[int, int]]:
         res = []
@@ -84,40 +94,40 @@ class _ResTransformer:
         return res
 
     def __transform_tuples(self, value: tuple[int, int]) -> tuple[int, int]:
-        values = self.__transform_array(value=array(value, dtype=int))
+        values = self.__transform_array(value=np.array(value, dtype=int))
         return int(values[0]), int(values[1])
 
     def from_fhd(self) -> tuple[UiOffsets, UiPos, UiRoi]:
         offsets = UiOffsets(
-            find_bullet_points_width=self.__transform(value=_FHD[0].find_bullet_points_width),
-            find_seperator_short_offset_top=self.__transform(value=_FHD[0].find_seperator_short_offset_top),
-            item_descr_line_height=self.__transform(value=_FHD[0].item_descr_line_height),
-            item_descr_off_bottom_edge=self.__transform(value=_FHD[0].item_descr_off_bottom_edge),
-            item_descr_pad=self.__transform(value=_FHD[0].item_descr_pad),
-            item_descr_width=self.__transform(value=_FHD[0].item_descr_width),
-            vendor_center_item_x=self.__transform(value=_FHD[0].vendor_center_item_x),
+            find_bullet_points_width=self.__transform(value=_FHD[1].find_bullet_points_width),
+            find_seperator_short_offset_top=self.__transform(value=_FHD[1].find_seperator_short_offset_top),
+            item_descr_line_height=self.__transform(value=_FHD[1].item_descr_line_height),
+            item_descr_off_bottom_edge=self.__transform(value=_FHD[1].item_descr_off_bottom_edge),
+            item_descr_pad=self.__transform(value=_FHD[1].item_descr_pad),
+            item_descr_width=self.__transform(value=_FHD[1].item_descr_width),
+            vendor_center_item_x=self.__transform(value=_FHD[1].vendor_center_item_x),
         )
         pos = UiPos(
-            possible_centers=self.__transform_list_of_tuples(value=_FHD[1].possible_centers),
-            window_dimensions=self.__transform_tuples(value=_FHD[1].window_dimensions),
+            possible_centers=self.__transform_list_of_tuples(value=_FHD[2].possible_centers),
+            window_dimensions=self.__transform_tuples(value=_FHD[2].window_dimensions),
         )
         roi = UiRoi(
-            core_skill=self.__transform_array(value=_FHD[2].core_skill),
-            health_slice=self.__transform_array(value=_FHD[2].health_slice),
-            hud_detection=self.__transform_array(value=_FHD[2].hud_detection),
-            mini_map_visible=self.__transform_array(value=_FHD[2].mini_map_visible),
-            rel_descr_search_left=self.__transform_array(value=_FHD[2].rel_descr_search_left, scaly_only=True),
-            rel_descr_search_right=self.__transform_array(value=_FHD[2].rel_descr_search_right, scaly_only=True),
-            rel_fav_flag=self.__transform_array(value=_FHD[2].rel_fav_flag, scaly_only=True),
-            rel_skill_cd=self.__transform_array(value=_FHD[2].rel_skill_cd, scaly_only=True),
-            skill3=self.__transform_array(value=_FHD[2].skill3),
-            skill4=self.__transform_array(value=_FHD[2].skill4),
-            slots_3x11=self.__transform_array(value=_FHD[2].slots_3x11),
-            slots_5x10=self.__transform_array(value=_FHD[2].slots_5x10),
-            sort_icon=self.__transform_array(value=_FHD[2].sort_icon),
-            stash_menu_icon=self.__transform_array(value=_FHD[2].stash_menu_icon),
-            tab_slots_6=self.__transform_array(value=_FHD[2].tab_slots_6),
-            vendor_text=self.__transform_array(value=_FHD[2].vendor_text),
+            core_skill=self.__transform_array(value=_FHD[3].core_skill),
+            health_slice=self.__transform_array(value=_FHD[3].health_slice),
+            hud_detection=self.__transform_array(value=_FHD[3].hud_detection),
+            mini_map_visible=self.__transform_array(value=_FHD[3].mini_map_visible),
+            rel_descr_search_left=self.__transform_array(value=_FHD[3].rel_descr_search_left, scale_only=True),
+            rel_descr_search_right=self.__transform_array(value=_FHD[3].rel_descr_search_right, scale_only=True),
+            rel_fav_flag=self.__transform_array(value=_FHD[3].rel_fav_flag, scale_only=True),
+            rel_skill_cd=self.__transform_array(value=_FHD[3].rel_skill_cd, scale_only=True),
+            skill3=self.__transform_array(value=_FHD[3].skill3),
+            skill4=self.__transform_array(value=_FHD[3].skill4),
+            slots_3x11=self.__transform_array(value=_FHD[3].slots_3x11),
+            slots_5x10=self.__transform_array(value=_FHD[3].slots_5x10),
+            sort_icon=self.__transform_array(value=_FHD[3].sort_icon),
+            stash_menu_icon=self.__transform_array(value=_FHD[3].stash_menu_icon),
+            tab_slots_6=self.__transform_array(value=_FHD[3].tab_slots_6),
+            vendor_text=self.__transform_array(value=_FHD[3].vendor_text),
         )
         return offsets, pos, roi
 
@@ -125,20 +135,10 @@ class _ResTransformer:
 @singleton
 class ResManager:
     def __init__(self):
-        self._offsets = _FHD[0]
-        self._pos = _FHD[1]
-        self._roi = _FHD[2]
-        self.transformers = {
-            "1920x1080": _ResTransformer(),
-            "2560x1080": _ResTransformer(width=2560),
-            "2560x1440": _ResTransformer(factor=4.0 / 3.0),
-            "2560x1600": _ResTransformer(factor=40.0 / 27.0, width=2560),
-            "3440x1440": _ResTransformer(factor=4.0 / 3.0, width=3440),
-            "3840x1080": _ResTransformer(width=3840, black_bars=(300, -300)),
-            "3840x1600": _ResTransformer(factor=40.0 / 27.0, width=3840),
-            "3840x2160": _ResTransformer(factor=2),
-            "5120x1440": _ResTransformer(factor=4.0 / 3.0, width=5120, black_bars=(400, -400)),
-        }
+        self._current_resolution = "1920x1080"
+        self._offsets = _FHD[1]
+        self._pos = _FHD[2]
+        self._roi = _FHD[3]
 
     @property
     def offsets(self) -> UiOffsets:
@@ -153,20 +153,21 @@ class ResManager:
         return self._roi
 
     def set_resolution(self, res: str):
-        if res not in self.transformers:
-            raise ValueError(f"Resolution {res} not supported")
+        if res == self._current_resolution:
+            return
+        self._current_resolution = res
         LOGGER.debug(f"Setting ui resolution to {res}")
-        self._offsets, self._pos, self._roi = self.transformers[res].from_fhd()
+        self._offsets, self._pos, self._roi = _ResTransformer(resolution=res).from_fhd()
 
 
 COLORS = Colors(
-    aspect_number=HSVRange(h_s_v_min=array([90, 60, 200]), h_s_v_max=array([150, 100, 255])),
-    cold_imbued=HSVRange(h_s_v_min=array([88, 0, 0]), h_s_v_max=array([112, 255, 255])),
-    legendary_orange=HSVRange(h_s_v_min=array([4, 190, 190]), h_s_v_max=array([26, 255, 255])),
-    material_color=HSVRange(h_s_v_min=array([86, 110, 190]), h_s_v_max=array([114, 220, 255])),
-    poison_imbued=HSVRange(h_s_v_min=array([55, 0, 0]), h_s_v_max=array([65, 255, 255])),
-    shadow_imbued=HSVRange(h_s_v_min=array([120, 0, 0]), h_s_v_max=array([140, 255, 255])),
-    skill_cd=HSVRange(h_s_v_min=array([5, 61, 38]), h_s_v_max=array([16, 191, 90])),
-    unique_gold=HSVRange(h_s_v_min=array([4, 45, 125]), h_s_v_max=array([26, 155, 250])),
-    unusable_red=HSVRange(h_s_v_min=array([0, 210, 110]), h_s_v_max=array([10, 255, 210])),
+    aspect_number=HSVRange(h_s_v_min=np.array([90, 60, 200]), h_s_v_max=np.array([150, 100, 255])),
+    cold_imbued=HSVRange(h_s_v_min=np.array([88, 0, 0]), h_s_v_max=np.array([112, 255, 255])),
+    legendary_orange=HSVRange(h_s_v_min=np.array([4, 190, 190]), h_s_v_max=np.array([26, 255, 255])),
+    material_color=HSVRange(h_s_v_min=np.array([86, 110, 190]), h_s_v_max=np.array([114, 220, 255])),
+    poison_imbued=HSVRange(h_s_v_min=np.array([55, 0, 0]), h_s_v_max=np.array([65, 255, 255])),
+    shadow_imbued=HSVRange(h_s_v_min=np.array([120, 0, 0]), h_s_v_max=np.array([140, 255, 255])),
+    skill_cd=HSVRange(h_s_v_min=np.array([5, 61, 38]), h_s_v_max=np.array([16, 191, 90])),
+    unique_gold=HSVRange(h_s_v_min=np.array([4, 45, 125]), h_s_v_max=np.array([26, 155, 250])),
+    unusable_red=HSVRange(h_s_v_min=np.array([0, 210, 110]), h_s_v_max=np.array([10, 255, 210])),
 )

--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,6 @@ from beautifultable import BeautifulTable
 
 from cam import Cam
 from config.loader import IniConfigLoader
-from config.ui import ResManager
 from item.filter import Filter
 from logger import Logger
 from overlay import Overlay
@@ -20,6 +19,7 @@ from version import __version__
 
 
 def main():
+    Logger.init(IniConfigLoader().advanced_options.log_lvl)
     # Create folders for logging stuff
     user_dir = os.path.expanduser("~")
     config_dir = Path(f"{user_dir}/.d4lf")
@@ -31,9 +31,6 @@ def main():
     start_detecting_window(win_spec)
     while not Cam().is_offset_set():
         wait(0.2)
-
-    ResManager().set_resolution(Cam().res_key)
-    Logger.init(IniConfigLoader().advanced_options.log_lvl)
 
     load_api()
 

--- a/src/scripts/vision_mode.py
+++ b/src/scripts/vision_mode.py
@@ -238,7 +238,6 @@ if __name__ == "__main__":
         start_detecting_window(win_spec)
         while not Cam().is_offset_set():
             wait(0.2)
-        ResManager().set_resolution(Cam().res_key)
         Filter().load_files()
         vision_mode()
     except:

--- a/src/template_finder.py
+++ b/src/template_finder.py
@@ -106,7 +106,9 @@ class SearchArgs:
 def stored_templates() -> dict[Template]:
     paths = []
     templates = {}
-    for path in [f"assets\\templates_{Cam().res_p}"]:
+    # TODO check if it works for higher res
+    closest = min([1080, 1440, 1600, 2160], key=lambda x: abs(x - int(Cam().res_p[:-1])))
+    for path in [f"assets\\templates_{closest}p"]:
         paths += list_files_in_folder(path)
     for file_path in paths:
         file_name: str = os.path.basename(file_path)

--- a/src/utils/window.py
+++ b/src/utils/window.py
@@ -86,7 +86,7 @@ def find_and_set_window_position(window_spec: WindowSpec):
         pos = GetClientRect(hwnd)
         top_left = ClientToScreen(hwnd, (pos[0], pos[1]))
         Cam().update_window_pos(top_left[0], top_left[1], pos[2], pos[3])
-    wait(0.5)
+    wait(1)
 
 
 def stop_detecting_window():

--- a/test/config/ui_test.py
+++ b/test/config/ui_test.py
@@ -1,17 +1,38 @@
+import numpy as np
 import pytest
 from natsort import natsorted
 
-from config.ui import ResManager, COLORS
+from config.ui import ResManager, COLORS, _ResTransformer
+
+_PIXELS = [np.array([0, 0]), np.array([1920, 0]), np.array([0, 1080]), np.array([1920, 1080])]
+_TESTS = [
+    ("1920x1080", (np.array(coord) for coord in [(0, 0), (1920, 0), (0, 1080), (1920, 1080)])),
+    ("1920x540", (np.array(coord) for coord in [(150, 0), (1770, 0), (150, 540), (1770, 540)])),
+    ("2560x1080", (np.array(coord) for coord in [(0, 0), (2560, 0), (0, 1080), (2560, 1080)])),
+    ("2560x1440", (np.array(coord) for coord in [(0, 0), (2560, 0), (0, 1440), (2560, 1440)])),
+    ("2560x1600", (np.array(coord) for coord in [(0, 0), (2560, 0), (0, 1600), (2560, 1600)])),
+    ("2560x720", (np.array(coord) for coord in [(200, 0), (2360, 0), (200, 720), (2360, 720)])),
+    ("3440x1440", (np.array(coord) for coord in [(0, 0), (3440, 0), (0, 1440), (3440, 1440)])),
+    ("3840x1080", (np.array(coord) for coord in [(300, 0), (3540, 0), (300, 1080), (3540, 1080)])),
+    ("3840x1600", (np.array(coord) for coord in [(0, 0), (3840, 0), (0, 1600), (3840, 1600)])),
+    ("3840x2160", (np.array(coord) for coord in [(0, 0), (3840, 0), (0, 2160), (3840, 2160)])),
+    ("5120x1440", (np.array(coord) for coord in [(400, 0), (4720, 0), (400, 1440), (4720, 1440)])),
+]
 
 
-@pytest.mark.parametrize("res", natsorted(ResManager().transformers), ids=natsorted(ResManager().transformers.keys()))
-def test_transformation(res):
-    if res == "1920x1080":
-        return
-    pos1 = ResManager().pos
+@pytest.mark.parametrize("res", natsorted([x[0] for x in _TESTS]), ids=natsorted([x[0] for x in _TESTS]))
+def test_set_resolution(res):
     ResManager().set_resolution(res)
-    pos2 = ResManager().pos
-    assert pos1 != pos2
+    assert ResManager().pos
+
+
+@pytest.mark.parametrize("pixel", _PIXELS, ids=[f"({x[0]},{x[1]})" for x in _PIXELS])
+@pytest.mark.parametrize("result", _TESTS, ids=[x[0] for x in _TESTS])
+def test_transformation(pixel, result):
+    new_pixel = _ResTransformer(result[0])._ResTransformer__transform_array(pixel)
+    expected = next(result[1])
+    assert new_pixel[0] == expected[0]
+    assert new_pixel[1] == expected[1]
 
 
 def test_colors():

--- a/test/item/find_descr_test.py
+++ b/test/item/find_descr_test.py
@@ -4,7 +4,6 @@ import cv2
 import pytest
 
 from cam import Cam
-from config.ui import ResManager
 from item.data.rarity import ItemRarity
 from item.find_descr import find_descr
 from template_finder import stored_templates
@@ -24,7 +23,6 @@ BASE_PATH = "test/assets/item"
 )
 def test_find_descr(img_res, input_img, anchor, expected_success, expected_top_left, expected_rarity):
     Cam().update_window_pos(0, 0, img_res[0], img_res[1])
-    ResManager().set_resolution(res=Cam().res_key)
     stored_templates.cache_clear()
     img = cv2.imread(input_img)
     start = time.time()

--- a/test/item/read_descr_test.py
+++ b/test/item/read_descr_test.py
@@ -4,7 +4,6 @@ import cv2
 import pytest
 
 from cam import Cam
-from config.ui import ResManager
 from item.data.affix import Affix
 from item.data.aspect import Aspect
 from item.data.item_type import ItemType
@@ -448,7 +447,6 @@ BASE_PATH = "test/assets/item"
 )
 def test_read_descr(img_res: tuple[int, int], input_img: str, expected_item: Item):
     Cam().update_window_pos(0, 0, img_res[0], img_res[1])
-    ResManager().set_resolution(res=Cam().res_key)
     stored_templates.cache_clear()
     img = cv2.imread(input_img)
     start = time.time()

--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -3,7 +3,6 @@ import time
 import cv2
 
 from cam import Cam
-from config.ui import ResManager
 from item.data.rarity import ItemRarity
 from item.descr.read_descr import read_descr
 from item.filter import Filter
@@ -15,7 +14,6 @@ def test_smoke():
     res = (2560, 1440)
     anchor = (1723, 1012)
     Cam().update_window_pos(0, 0, *res)
-    ResManager().set_resolution(res=Cam().res_key)
     stored_templates.cache_clear()
     img = cv2.imread("test/assets/item/find_descr_legendary_1440p.png")
     start = time.time()

--- a/test/ui/char_inventory_test.py
+++ b/test/ui/char_inventory_test.py
@@ -2,7 +2,6 @@ import cv2
 import pytest
 
 from cam import Cam
-from config.ui import ResManager
 from template_finder import stored_templates
 from ui.char_inventory import CharInventory
 
@@ -21,7 +20,6 @@ BASE_PATH = "test/assets/ui"
 )
 def test_char_inventory(img_res, input_img):
     Cam().update_window_pos(0, 0, img_res[0], img_res[1])
-    ResManager().set_resolution(res=Cam().res_key)
     stored_templates.cache_clear()
     img = cv2.imread(input_img)
     inv = CharInventory()
@@ -38,7 +36,6 @@ def test_char_inventory(img_res, input_img):
 )
 def test_get_item_slots(img_res, input_img, occupied, junk, fav):
     Cam().update_window_pos(0, 0, img_res[0], img_res[1])
-    ResManager().set_resolution(res=Cam().res_key)
     stored_templates.cache_clear()
     img = cv2.imread(input_img)
     inv = CharInventory()

--- a/test/ui/chest_test.py
+++ b/test/ui/chest_test.py
@@ -2,7 +2,6 @@ import cv2
 import pytest
 
 from cam import Cam
-from config.ui import ResManager
 from template_finder import stored_templates
 from ui.chest import Chest
 
@@ -17,7 +16,6 @@ BASE_PATH = "test/assets/ui"
 )
 def test_chest(img_res, input_img):
     Cam().update_window_pos(0, 0, img_res[0], img_res[1])
-    ResManager().set_resolution(res=Cam().res_key)
     stored_templates.cache_clear()
     img = cv2.imread(input_img)
     inv = Chest()


### PR DESCRIPTION
- Refactored scaling to support all resolutions. Resolution scaling and black bars are calculated according to D4 specifications. Everything greater than 16 / 10 aspect ratio is supported. Lower than 16/10 will introduce black bars on top/bottom (easy to calc) but some strange ui shift which I'm not able to calculate. Since these res are very uncommon anyways, I don't think this is a problem
- Recalculate scaling every time a the d4 window is found/moved/resized/...
- Only read config from the user folder if the params.ini file there is not empty