### PR TITLE
Fix check_chest_tabs and added Glacial Fissure sigil dungeon

### DIFF
--- a/assets/lang/enUS/sigils.json
+++ b/assets/lang/enUS/sigils.json
@@ -119,7 +119,8 @@
         "sealed_archives": "sealed archives",
         "seaside_descent": "seaside descent",
         "shifting_city": "shifting city",
-        "whispering_vault": "whispering vault"
+        "whispering_vault": "whispering vault",
+        "glacial_fissure": "glacial_fissure"
     },
     "minor": {
         "monster_crowd_control_resist": "monster crowd control resist crowd control duration vs monsters is reduced by .",

--- a/src/loot_filter.py
+++ b/src/loot_filter.py
@@ -102,7 +102,7 @@ def run_loot_filter():
 
     if chest.is_open():
         for i in IniConfigLoader().general.check_chest_tabs:
-            chest.switch_to_tab(i)
+            chest.switch_to_tab(i - 1)
             wait(0.5)
             check_items(chest)
         wait(0.5)


### PR DESCRIPTION
When we set the check_chest_tabs value in the config to 1.2, the tab index started at 1 and started by checking the 2nd tab. Therefore, by setting it to -1, it worked correctly by starting from index 0

Added Glacial Fissure sigil dungeon for The Beast in the Ice Dungeon