### PR TITLE
add delay for inventory open

### DIFF
--- a/src/loot_filter.py
+++ b/src/loot_filter.py
@@ -20,8 +20,9 @@ from utils.window import screenshot
 
 def check_items(inv: InventoryBase):
     occupied, _ = inv.get_item_slots()
-
-    Logger.info(f"Items: {len(occupied)} in {inv.menu_name}")
+    num_fav = sum(1 for slot in occupied if slot.is_fav)
+    num_junk = sum(1 for slot in occupied if slot.is_junk)
+    Logger.info(f"Items: {len(occupied)} (favorite: {num_fav}, junk: {num_junk}) in {inv.menu_name}")
     start_time = None
     for item in occupied:
         if item.is_junk or item.is_fav:

--- a/src/ui/char_inventory.py
+++ b/src/ui/char_inventory.py
@@ -19,3 +19,4 @@ class CharInventory(InventoryBase):
         self.open_method = ToggleMethod.HOTKEY
         self.close_hotkey = "esc"
         self.close_method = ToggleMethod.HOTKEY
+        self.delay = 1  # Needed as they added a "fad-in" for the items

--- a/src/ui/menu.py
+++ b/src/ui/menu.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from logger import Logger
 from template_finder import SearchArgs, TemplateMatch, SearchResult
-from utils.misc import run_until_condition
+from utils.misc import run_until_condition, wait
 from utils.mouse_selector import select_search_result
 
 
@@ -25,6 +25,7 @@ class Menu:
         self.close_hotkey: str = "esc"
         self.open_method: ToggleMethod = ToggleMethod.BUTTON
         self.close_method: ToggleMethod = ToggleMethod.HOTKEY
+        self.delay = 0
 
     @staticmethod
     def select_button(search: SearchArgs | TemplateMatch) -> bool:
@@ -114,6 +115,7 @@ class Menu:
         _, success = run_until_condition(self.is_open, lambda res: res, timeout)
         if not success:
             Logger.warning(f"Could not find {self.menu_name} after {timeout} seconds")
+        wait(self.delay)
         return success
 
     def wait_until_closed(self, timeout: float = 10, mode: str = "all") -> bool:


### PR DESCRIPTION
Needed cause they added a "fade-in" for the items. What happens when starting the auto filter and d4lf needs to open the inventory itself is that the items are not properly visible while d4lf thinks inventory is open. Based on that image the favorite, junk, occupied detection isnt working.