### PR TITLE
Fix sigil filter

### DIFF
--- a/src/config/models.py
+++ b/src/config/models.py
@@ -284,7 +284,7 @@ class ProfileModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str
     Affixes: list[DynamicItemFilterModel] = []
-    Sigils: SigilFilterModel = SigilFilterModel()
+    Sigils: SigilFilterModel | None = None
     Uniques: list[UniqueModel] = []
 
 

--- a/src/item/filter.py
+++ b/src/item/filter.py
@@ -104,6 +104,10 @@ class Filter:
 
     def _check_sigil(self, item: Item) -> FilterResult:
         res = FilterResult(False, [])
+        if not self.sigil_filters.items():
+            Logger.info("Matched Sigils")
+            res.keep = True
+            res.matched.append(MatchedFilter("default"))
         for profile_name, profile_filter in self.sigil_filters.items():
             # check item power
             if not self._match_item_power(max_power=profile_filter.maxTier, min_power=profile_filter.minTier, item_power=item.power):


### PR DESCRIPTION
- Default for Sigils was broken. If not all files contained a sigil filter, it was always marked as keep.