### PR TITLE
Fix mobalytics community build imports

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "5.6.0beta4"
+__version__ = "5.6.0beta5"

--- a/src/gui/importer/common.py
+++ b/src/gui/importer/common.py
@@ -100,10 +100,10 @@ def get_class_name(input_str: str) -> str:
     return "Unknown"
 
 
-def get_with_retry(url: str, custom_headers = {}) -> httpx.Response:
+def get_with_retry(url: str, custom_headers: dict[str, str] | None = None) -> httpx.Response:
     for _ in range(10):
         try:
-            r = httpx.get(url, headers={**HEADERS, **custom_headers})
+            r = httpx.get(url, headers=custom_headers if custom_headers is not None else HEADERS)
         except httpx.ReadTimeout:
             LOGGER.debug(f"Request {url} timed out, retrying...")
             continue

--- a/src/gui/importer/common.py
+++ b/src/gui/importer/common.py
@@ -100,10 +100,10 @@ def get_class_name(input_str: str) -> str:
     return "Unknown"
 
 
-def get_with_retry(url: str) -> httpx.Response:
+def get_with_retry(url: str, custom_headers = {}) -> httpx.Response:
     for _ in range(10):
         try:
-            r = httpx.get(url, headers=HEADERS)
+            r = httpx.get(url, headers={**HEADERS, **custom_headers})
         except httpx.ReadTimeout:
             LOGGER.debug(f"Request {url} timed out, retrying...")
             continue

--- a/src/gui/importer/mobalytics.py
+++ b/src/gui/importer/mobalytics.py
@@ -50,7 +50,7 @@ def import_mobalytics(url: str):
     url = _fix_input_url(url=url)
     LOGGER.info(f"Loading {url}")
     try:
-        r = get_with_retry(url=url, custom_headers={"User-Agent": "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"})
+        r = get_with_retry(url=url, custom_headers={})
     except ConnectionError as exc:
         LOGGER.exception(msg := "Couldn't get build")
         raise MobalyticsException(msg) from exc
@@ -159,6 +159,7 @@ if __name__ == "__main__":
     os.chdir(pathlib.Path(__file__).parent.parent.parent.parent)
     URLS = [
         "https://mobalytics.gg/diablo-4/builds/barbarian/bash",
+        "https://mobalytics.gg/diablo-4/profile/3aeadb5c-522e-47b9-9a17-cdeaaa58909c/builds/4bb9a04e-da1e-449f-91ab-ca29e5727a20",
     ]
     for X in URLS:
         import_mobalytics(url=X)

--- a/src/gui/importer/mobalytics.py
+++ b/src/gui/importer/mobalytics.py
@@ -50,7 +50,7 @@ def import_mobalytics(url: str):
     url = _fix_input_url(url=url)
     LOGGER.info(f"Loading {url}")
     try:
-        r = get_with_retry(url=url)
+        r = get_with_retry(url=url, custom_headers={"User-Agent": "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"})
     except ConnectionError as exc:
         LOGGER.exception(msg := "Couldn't get build")
         raise MobalyticsException(msg) from exc

--- a/tests/gui/importer/test_diablo_trade.py
+++ b/tests/gui/importer/test_diablo_trade.py
@@ -14,4 +14,4 @@ URLS = [
 def test_import_diablo_trade(url: str, mock_ini_loader: MockerFixture, mocker: MockerFixture):
     Dataloader()  # need to load data first or the mock will make it impossible
     mocker.patch("builtins.open", new=mocker.mock_open())
-    import_diablo_trade(url=url, max_listings=100)
+    import_diablo_trade(url=url, max_listings=30)

--- a/tests/gui/importer/test_mobalytics.py
+++ b/tests/gui/importer/test_mobalytics.py
@@ -18,6 +18,8 @@ URLS = [
     "https://mobalytics.gg/diablo-4/builds/sorcerer/firewall-scorched-earth",
     "https://mobalytics.gg/diablo-4/builds/sorcerer/kripp-s-ultimate-fire-sorc",
     "https://mobalytics.gg/diablo-4/builds/sorcerer/nicktew-s4-blizzard",
+    "https://mobalytics.gg/diablo-4/profile/3aeadb5c-522e-47b9-9a17-cdeaaa58909c/builds/4bb9a04e-da1e-449f-91ab-ca29e5727a20"
+    "https://mobalytics.gg/diablo-4/profile/bd7d970b-813c-4f98-b8b5-d5ca637f7ec0/builds/9ed37972-f738-4d1e-a231-e9f0f367c848",
 ]
 
 

--- a/tests/gui/importer/test_mobalytics.py
+++ b/tests/gui/importer/test_mobalytics.py
@@ -18,7 +18,7 @@ URLS = [
     "https://mobalytics.gg/diablo-4/builds/sorcerer/firewall-scorched-earth",
     "https://mobalytics.gg/diablo-4/builds/sorcerer/kripp-s-ultimate-fire-sorc",
     "https://mobalytics.gg/diablo-4/builds/sorcerer/nicktew-s4-blizzard",
-    "https://mobalytics.gg/diablo-4/profile/3aeadb5c-522e-47b9-9a17-cdeaaa58909c/builds/4bb9a04e-da1e-449f-91ab-ca29e5727a20"
+    "https://mobalytics.gg/diablo-4/profile/3aeadb5c-522e-47b9-9a17-cdeaaa58909c/builds/4bb9a04e-da1e-449f-91ab-ca29e5727a20",
     "https://mobalytics.gg/diablo-4/profile/bd7d970b-813c-4f98-b8b5-d5ca637f7ec0/builds/9ed37972-f738-4d1e-a231-e9f0f367c848",
 ]
 


### PR DESCRIPTION
Mobalytics imports failed due to the user-agent header. Added a custom_header for mobalytics to work with normal and community builds.