### PR TITLE
Speed up OCR

### DIFF
--- a/benchmarks/imageproc.py
+++ b/benchmarks/imageproc.py
@@ -166,9 +166,8 @@ if __name__ == "__main__":
     try:
         save_results(
             [
-                # TODO REMOVE COMMENT
-                # BenchHelper(resolution=(1920, 1080), anchor=Anchor(icon_width=55, start_x=1240, y=760)).run(),
-                # BenchHelper(resolution=(2560, 1440), anchor=Anchor(icon_width=70, start_x=1685, y=980)).run(),
+                BenchHelper(resolution=(1920, 1080), anchor=Anchor(icon_width=55, start_x=1240, y=760)).run(),
+                BenchHelper(resolution=(2560, 1440), anchor=Anchor(icon_width=70, start_x=1685, y=980)).run(),
                 BenchHelper(resolution=(3840, 2160), anchor=Anchor(icon_width=105, start_x=2515, y=1495)).run(),
             ]
         )

--- a/benchmarks/imageproc.py
+++ b/benchmarks/imageproc.py
@@ -65,7 +65,8 @@ def bench_func(func, *args):
 
 
 def bench_helper(func, *args):
-    runs = max(math.ceil(10 / bench_func(func, *args)), 10)
+    # check how long it would take to run the function. aim for 5 seconds (*2 due to overhead). min 10 runs, max 50
+    runs = max(min(math.ceil(5 / bench_func(func, *args)), 50), 10)
     return [bench_func(func, *args) for _ in range(runs)]
 
 
@@ -165,8 +166,9 @@ if __name__ == "__main__":
     try:
         save_results(
             [
-                BenchHelper(resolution=(1920, 1080), anchor=Anchor(icon_width=55, start_x=1240, y=760)).run(),
-                BenchHelper(resolution=(2560, 1440), anchor=Anchor(icon_width=70, start_x=1685, y=980)).run(),
+                # TODO REMOVE COMMENT
+                # BenchHelper(resolution=(1920, 1080), anchor=Anchor(icon_width=55, start_x=1240, y=760)).run(),
+                # BenchHelper(resolution=(2560, 1440), anchor=Anchor(icon_width=70, start_x=1685, y=980)).run(),
                 BenchHelper(resolution=(3840, 2160), anchor=Anchor(icon_width=105, start_x=2515, y=1495)).run(),
             ]
         )

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,5 @@
 import concurrent.futures
 
 TP = concurrent.futures.ThreadPoolExecutor()
-__version__ = "5.6.0"
+
+__version__ = "5.6.1"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,4 @@
+import concurrent.futures
+
+TP = concurrent.futures.ThreadPoolExecutor()
 __version__ = "5.6.0"

--- a/src/gui/qt_gui.py
+++ b/src/gui/qt_gui.py
@@ -3,7 +3,7 @@ import os
 import sys
 import threading
 
-from PyQt6.QtCore import QObject, QRegularExpression, QRunnable, QThreadPool, pyqtSignal, pyqtSlot
+from PyQt6.QtCore import QObject, QPoint, QRegularExpression, QRunnable, QSettings, QSize, QThreadPool, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QColor, QIcon, QRegularExpressionValidator
 from PyQt6.QtWidgets import (
     QApplication,
@@ -52,11 +52,15 @@ def start_gui():
 class Gui(QMainWindow):
     def __init__(self):
         super().__init__()
+        self.settings = QSettings("d4lf", "gui")
 
         self.setWindowTitle(f"D4LF v{__version__}")
-        self.setGeometry(0, 0, 650, 800)
 
-        self.showMaximized()
+        self.resize(self.settings.value("size", QSize(650, 800)))
+        self.move(self.settings.value("pos", QPoint(0, 0)))
+
+        if self.settings.value("maximized", "true") == "true":
+            self.showMaximized()
 
         self.tab_widget = QTabWidget(self)
         self.tab_widget.setTabBar(_CustomTabBar())
@@ -69,6 +73,15 @@ class Gui(QMainWindow):
         LOGGER.root.addHandler(self.maxroll_log_handler)
         self.tab_widget.currentChanged.connect(self._handle_tab_changed)
         self._toggle_dark_mode()
+
+    def closeEvent(self, e):
+        # Write window size, position, and maximized status to config
+        if not self.isMaximized():  # Don't want to save the maximized positioning
+            self.settings.setValue("size", self.size())
+            self.settings.setValue("pos", self.pos())
+        self.settings.setValue("maximized", self.isMaximized())
+
+        e.accept()
 
     def _diablo_trade_tab(self):
         tab_diablo_trade = QWidget(self)

--- a/src/item/descr/read_descr.py
+++ b/src/item/descr/read_descr.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 
+from src import TP
 from src.config.ui import ResManager
 from src.item.data.item_type import ItemType
 from src.item.data.rarity import ItemRarity
@@ -16,6 +17,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def read_descr(rarity: ItemRarity, img_item_descr: np.ndarray, show_warnings: bool = True) -> Item | None:
+    futures = {}
     base_item = Item(rarity=rarity)
 
     # Find textures for seperator short on top
@@ -72,51 +74,55 @@ def read_descr(rarity: ItemRarity, img_item_descr: np.ndarray, show_warnings: bo
     # Find inherent affixes
     # =========================
     is_sigil = item.item_type == ItemType.Sigil
-    line_height = ResManager().offsets.item_descr_line_height
-    if len(inhernet_affixe_bullets) > 0 and len(affix_bullets) > 0:
-        bottom_limit = affix_bullets[0].center[1] - int(line_height // 2)
-        item.inherent, debug_str = find_affixes(
-            img_item_descr=img_item_descr,
-            affix_bullets=inhernet_affixe_bullets,
-            bottom_limit=bottom_limit,
-            is_sigil=is_sigil,
-            is_inherent=True,
-        )
-        if item.inherent is None:
-            item.inherent, debug_str = find_affixes(
+
+    def _get_inherent():
+        line_height = ResManager().offsets.item_descr_line_height
+        if len(inhernet_affixe_bullets) > 0 and len(affix_bullets) > 0:
+            bottom_limit = affix_bullets[0].center[1] - int(line_height // 2)
+            i_inherent, debug_str = find_affixes(
                 img_item_descr=img_item_descr,
                 affix_bullets=inhernet_affixe_bullets,
                 bottom_limit=bottom_limit,
                 is_sigil=is_sigil,
                 is_inherent=True,
-                do_pre_proc_flag=False,
             )
-        if item.inherent is None:
-            if show_warnings:
-                LOGGER.warning(f"Could not find inherent: {debug_str}")
-                screenshot("failed_inherent", img=img_item_descr)
-            return None
+            if i_inherent is None:
+                i_inherent, debug_str = find_affixes(
+                    img_item_descr=img_item_descr,
+                    affix_bullets=inhernet_affixe_bullets,
+                    bottom_limit=bottom_limit,
+                    is_sigil=is_sigil,
+                    is_inherent=True,
+                    do_pre_proc_flag=False,
+                )
+            return i_inherent, debug_str
+        return [], ""
+
+    futures["inherent"] = TP.submit(_get_inherent)
 
     # Find normal affixes
     # =========================
-    if aspect_bullet is not None:
-        bottom_limit = aspect_bullet.center[1]
-    elif len(empty_sockets) > 0:
-        bottom_limit = empty_sockets[0].center[1]
-    else:
-        bottom_limit = img_item_descr.shape[0]
-    item.affixes, debug_str = find_affixes(
-        img_item_descr=img_item_descr, affix_bullets=affix_bullets, bottom_limit=bottom_limit, is_sigil=is_sigil
-    )
-    if item.affixes is None:
-        item.affixes, debug_str = find_affixes(
-            img_item_descr=img_item_descr, affix_bullets=affix_bullets, bottom_limit=bottom_limit, is_sigil=is_sigil, do_pre_proc_flag=False
+    def _get_affixes():
+        if aspect_bullet is not None:
+            bottom_limit = aspect_bullet.center[1]
+        elif len(empty_sockets) > 0:
+            bottom_limit = empty_sockets[0].center[1]
+        else:
+            bottom_limit = img_item_descr.shape[0]
+        i_affixes, debug_str = find_affixes(
+            img_item_descr=img_item_descr, affix_bullets=affix_bullets, bottom_limit=bottom_limit, is_sigil=is_sigil
         )
-    if item.affixes is None:
-        if show_warnings:
-            LOGGER.warning(f"Could not find affix: {debug_str}")
-            screenshot("failed_affixes", img=img_item_descr)
-        return None
+        if i_affixes is None:
+            i_affixes, debug_str = find_affixes(
+                img_item_descr=img_item_descr,
+                affix_bullets=affix_bullets,
+                bottom_limit=bottom_limit,
+                is_sigil=is_sigil,
+                do_pre_proc_flag=False,
+            )
+        return i_affixes, debug_str
+
+    futures["affixes"] = TP.submit(_get_affixes)
 
     # Find aspects of uniques
     # =========================
@@ -129,5 +135,19 @@ def read_descr(rarity: ItemRarity, img_item_descr: np.ndarray, show_warnings: bo
                 LOGGER.warning(f"Could not find unique: {debug_str}")
                 screenshot("failed_aspect_or_unique", img=img_item_descr)
             return None
+
+    item.affixes, debug_str = futures["affixes"].result()
+    if item.affixes is None:
+        if show_warnings:
+            LOGGER.warning(f"Could not find affix: {debug_str}")
+            screenshot("failed_affixes", img=img_item_descr)
+        return None
+
+    item.inherent, debug_str = futures["inherent"].result()
+    if item.inherent is None:
+        if show_warnings:
+            LOGGER.warning(f"Could not find inherent: {debug_str}")
+            screenshot("failed_inherent", img=img_item_descr)
+        return None
 
     return item

--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,6 @@ from src.gui.qt_gui import start_gui
 from src.item.filter import Filter
 from src.logger import LOG_DIR
 from src.overlay import Overlay
-from src.utils.ocr.read import load_api
 from src.utils.process_handler import safe_exit
 from src.utils.window import WindowSpec, start_detecting_window
 
@@ -55,8 +54,6 @@ def main():
     start_detecting_window(win_spec)
     while not Cam().is_offset_set():
         time.sleep(0.2)
-
-    load_api()
 
     overlay = None
 

--- a/src/template_finder.py
+++ b/src/template_finder.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 import logging
 import threading
 import time
@@ -7,6 +6,7 @@ from dataclasses import dataclass
 import cv2
 import numpy as np
 
+from src import TP
 from src.cam import Cam
 from src.config.data import COLORS, Template
 from src.config.ui import ResManager
@@ -16,7 +16,6 @@ from src.utils.roi_operations import get_center
 
 LOGGER = logging.getLogger(__name__)
 
-EXECUTOR = concurrent.futures.ThreadPoolExecutor()
 TEMPLATES_LOCK = threading.Lock()
 
 
@@ -252,7 +251,7 @@ def search(
         img = Cam().grab() if inp_img is None else inp_img
         if do_multi_process:
             for template in templates:
-                future = EXECUTOR.submit(_process_cv_result, template, img)
+                future = TP.submit(_process_cv_result, template, img)
                 future_list.append(future)
 
                 for i in future_list:

--- a/tests/item/find_descr_test.py
+++ b/tests/item/find_descr_test.py
@@ -4,10 +4,11 @@ import cv2
 import pytest
 
 from src.cam import Cam
+from src.config import BASE_DIR
 from src.item.data.rarity import ItemRarity
 from src.item.find_descr import find_descr
 
-BASE_PATH = "tests/assets/item"
+BASE_PATH = BASE_DIR / "tests/assets/item"
 
 
 @pytest.mark.parametrize(

--- a/tests/item/read_descr_test.py
+++ b/tests/item/read_descr_test.py
@@ -1,9 +1,8 @@
-import time
-
 import cv2
 import pytest
 
 from src.cam import Cam
+from src.config import BASE_DIR
 from src.item.data.affix import Affix, AffixType
 from src.item.data.item_type import ItemType
 from src.item.data.rarity import ItemRarity
@@ -11,7 +10,7 @@ from src.item.descr.read_descr import read_descr
 from src.item.models import Item
 
 # def read_descr(rarity: ItemRarity, img_item_descr: np.ndarray) -> Item:
-BASE_PATH = "tests/assets/item"
+BASE_PATH = BASE_DIR / "tests/assets/item"
 
 legendary = [
     (
@@ -337,9 +336,7 @@ sigil = [
 def _run_test_helper(img_res: tuple[int, int], input_img: str, expected_item: Item):
     Cam().update_window_pos(0, 0, *img_res)
     img = cv2.imread(input_img)
-    start = time.time()
     item = read_descr(expected_item.rarity, img)
-    print("Runtime (read_descr()): ", time.time() - start)
     assert item == expected_item
 
 

--- a/tests/ui/char_inventory_test.py
+++ b/tests/ui/char_inventory_test.py
@@ -2,9 +2,10 @@ import cv2
 import pytest
 
 from src.cam import Cam
+from src.config import BASE_DIR
 from src.ui.char_inventory import CharInventory
 
-BASE_PATH = "tests/assets/ui"
+BASE_PATH = BASE_DIR / "tests/assets/ui"
 
 
 @pytest.mark.parametrize(

--- a/tests/ui/chest_test.py
+++ b/tests/ui/chest_test.py
@@ -2,9 +2,10 @@ import cv2
 import pytest
 
 from src.cam import Cam
+from src.config import BASE_DIR
 from src.ui.chest import Chest
 
-BASE_PATH = "tests/assets/ui"
+BASE_PATH = BASE_DIR / "tests/assets/ui"
 
 
 @pytest.mark.parametrize(("img_res", "input_img"), [((3440, 1440), f"{BASE_PATH}/chest_open_1440p_wide.png")])


### PR DESCRIPTION
- Defined a central ThreadPool that is used everywhere for better resource allocation.
- Utilized the ThreadPool in `read_descr` for increased parallelism.
- Refactored `ocr.read` to allow multiple threads by introducing an APILoader.
- Fixed some tests to allow them to run independently of the current working directory.

Speeds up read_descr by about 15% on my desktop