### PR TITLE
Added ability to configure how uniques that do not match a filter are handled, and additionally added unique importing to importers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 !config/bnip/.gitkeep
 *.bak
+*.lock
 *.log
 *.pyc
 *.pyo

--- a/README.md
+++ b/README.md
@@ -72,19 +72,20 @@ The config folder in `C:/Users/<WINDOWS_USER>/.d4lf` contains:
 
 ### params.ini
 
-| [general]                                         | Description                                                                                                                                                                                                                                                                                                                  |
-|---------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| profiles                                          | A set of profiles separated by comma. d4lf will look for these yaml files in config/profiles and in C:/Users/WINDOWS_USER/.d4lf/profiles                                                                                                                                                                                     |
-| keep_aspects                                      | - `all`: Keep all legendary items <br>- `upgrade`: Keep all legendary items that upgrade your codex of power <br>- `none`: Keep no legendary items based on aspect (they are still filtered!)                                                                                                                                |
-| handle_rares                                      | - `filter`: Filter them based on your profiles <br>- `ignore`: Ignores all rares, vision mode shows them as blue and auto mode never junks or favorites them <br>- `junk`: Vision mode shows them always as red, auto mode always junks rares                                                                                |
-| run_vision_mode_on_startup                        | If the vision mode should automatically start when starting d4lf. Otherwise has to be started manually with the vision button or the hotkey                                                                                                                                                                                  |
-| check_chest_tabs                                  | Which chest tabs will be checked and filtered for items in case chest is open when starting the filter. You need to buy all slots. Counting is done left to right. E.g. 1,2,4 will check tab 1, tab 2, tab 4                                                                                                                 |
-| move_to_inv_item_type<br/>move_to_stash_item_type | Which types of items to move when using fast move functionality. Will only affect tabs defined in check_chest_tabs. You can select more than one option. <br>- `favorites`: Move favorites only <br>- `junk`: Move junk only <br>- `unmarked`: Only items not marked as favorite or junk <br>- `everything`: Move everything |
-| mark_as_favorite                                  | Whether to favorite matched items or not. Defaults to true                                                                                                                                                                                                                                                                   |
-| minimum_overlay_font_size                         | The minimum font size for the vision overlay, specifically the green text that shows which filter(s) are matching. Note: For small profile names, the font may actually be larger than this size but will never go below this size.                                                                                          |
-| hidden_transparency                               | The overlay will become transparent after not hovering it for a while. This can be changed by specifying any value between [0, 1] with 0 being completely invisible and 1 completely visible                                                                                                                                 |
-| browser                                           | Which browser to use to get builds, please make sure you pick an installed browser: chrome, edge or firefox are currently supported                                                                                                                                                                                          |
-| full_dump                                         | When using the import build feature, whether to use the full dump (e.g. contains all filter items) or not                                                                                                                                                                                                                    |
+| [general]                                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|---------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| profiles                                          | A set of profiles separated by comma. d4lf will look for these yaml files in config/profiles and in C:/Users/WINDOWS_USER/.d4lf/profiles                                                                                                                                                                                                                                                                                                 |
+| keep_aspects                                      | - `all`: Keep all legendary items <br>- `upgrade`: Keep all legendary items that upgrade your codex of power <br>- `none`: Keep no legendary items based on aspect (they are still filtered!)                                                                                                                                                                                                                                            |
+| handle_rares                                      | - `filter`: Filter them based on your profiles <br>- `ignore`: Ignores all rares, vision mode shows them as blue and auto mode never junks or favorites them <br>- `junk`: Vision mode shows them always as red, auto mode always junks rares                                                                                                                                                                                            |
+| handle_uniques                                    | How to handle uniques that do not match any filter. This property does not apply to filtered uniques. All mythics are favorited regardless of filter. <br/>- `favorite`: Mark the unique as favorite and vision mode will show it as green (default)<br/>- `ignore`: Do nothing with the unique and vision mode will show it as green<br/>- `junk`: Mark any uniques that don't match any filters as junk and show as red in vision mode |
+| run_vision_mode_on_startup                        | If the vision mode should automatically start when starting d4lf. Otherwise has to be started manually with the vision button or the hotkey                                                                                                                                                                                                                                                                                              |
+| check_chest_tabs                                  | Which chest tabs will be checked and filtered for items in case chest is open when starting the filter. You need to buy all slots. Counting is done left to right. E.g. 1,2,4 will check tab 1, tab 2, tab 4                                                                                                                                                                                                                             |
+| move_to_inv_item_type<br/>move_to_stash_item_type | Which types of items to move when using fast move functionality. Will only affect tabs defined in check_chest_tabs. You can select more than one option. <br>- `favorites`: Move favorites only <br>- `junk`: Move junk only <br>- `unmarked`: Only items not marked as favorite or junk <br>- `everything`: Move everything                                                                                                             |
+| mark_as_favorite                                  | Whether to favorite matched items or not. Defaults to true                                                                                                                                                                                                                                                                                                                                                                               |
+| minimum_overlay_font_size                         | The minimum font size for the vision overlay, specifically the green text that shows which filter(s) are matching. Note: For small profile names, the font may actually be larger than this size but will never go below this size.                                                                                                                                                                                                      |
+| hidden_transparency                               | The overlay will become transparent after not hovering it for a while. This can be changed by specifying any value between [0, 1] with 0 being completely invisible and 1 completely visible                                                                                                                                                                                                                                             |
+| browser                                           | Which browser to use to get builds, please make sure you pick an installed browser: chrome, edge or firefox are currently supported                                                                                                                                                                                                                                                                                                      |
+| full_dump                                         | When using the import build feature, whether to use the full dump (e.g. contains all filter items) or not                                                                                                                                                                                                                                                                                                                                |
 
 | [char]    | Description                       |
 |-----------|-----------------------------------|
@@ -340,9 +341,21 @@ names in [assets/lang/enUS/sigils.json](assets/lang/enUS/sigils.json).
 ### Uniques
 
 Uniques are defined by the top-level key `Uniques`. It contains a list of parameters that you want to filter for. If no
-Unique filter is provided, all unique items will be kept.
-Uniques can be filtered similar to [Affixes](#Affixes) but due to their nature of fixed
-effects, you only have to specify the thresholds that you want to apply.
+Unique filter is provided, uniques will be handled according to the handle_uniques configuration. All mythics are 
+marked as favorite regardless of any filter or configuration.
+
+Uniques can be filtered in two ways. First the aspect and affix for a specific unique can be filtered directly. 
+This is how imported profiles are configured. If only aspect filtering is applied, then all other uniques will be 
+handled according to the handle_uniques property. For aspect filtering, since uniques all have a predefined affix,
+you'll only need to specify the threshold that you want to apply (see examples below).
+
+Additionally, you can filter all uniques based on a generic property like their item power or if they have greater 
+affixes. Once a "global" filter like this is applied then all uniques will have a filter that now applies to them 
+and handle_uniques will be ignored.
+
+In vision mode, uniques show as <filename>.<aspect>. For example myuniques.yaml with fists_of_fate aspect defined 
+would show as myuniques.fists_of_fate. The label for the filename can be configured at the aspect level using the 
+profileAlias flag (see examples). 
 
 <details><summary>Config Examples</summary>
 
@@ -353,7 +366,7 @@ Uniques:
 ```
 
 ```yaml
-# Take all uniques with item power > 800
+# Take all uniques with item power > 900
 Uniques:
   - minPower: 900
 ```
@@ -380,20 +393,22 @@ Uniques:
 ```yaml
 # Take all Tibault's Will pants
 Uniques:
-  - aspect: [ tibaults_will ]
+  - aspect: { name: tibaults_will } 
 ```
 
 ```yaml
-# Take all Tibault's Will pants with at least 2 greater affixes
+# Take all Tibault's Will pants with at least 2 greater affixes.
+# Have vision mode show this as my_cool_items.tibaults_will instead of <filename>.tibaults_will
 Uniques:
-  - aspect: [ tibaults_will ]
+  - aspect: { name: tibaults_will }
     minGreaterAffixCount: 2
+    profileAlias: my_cool_items
 ```
 
 ```yaml
 # Take all Tibault's Will pants that have item power > 900 and dmg reduction from close > 12 as well as aspect value > 25
 Uniques:
-  - aspect: [ tibaults_will, 25 ]
+  - aspect: { name: tibaults_will, value: 25 }
     minPower: 900
     affix:
       - { name: damage_reduction_from_close_enemies, value: 12 }

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Documentation is not yet finished. For now, it should be self-explanatory. Just 
 Current functionality:
 
 - Import builds from maxroll/d4builds/mobalytics
-- Create profiles based off of searches for diablo.trade
+- Create profiles based off of searches for diablo.trade (requires chrome)
 - Complete management of your params.ini through the config tab
 
 Each tab gives further instructions on how to use it and what kind of input it expects.

--- a/assets/lang/enUS/affixes.json
+++ b/assets/lang/enUS/affixes.json
@@ -369,6 +369,7 @@
     "maximum_life_while_dark_shroud_is_active": "maximum life while dark shroud is active",
     "maximum_mana": "maximum mana",
     "maximum_minion_life": "maximum minion life",
+    "maximum_poison_resistance": "maximum poison resistance",
     "maximum_resistance": "maximum resistance",
     "maximum_resistance_to_all_elements": "maximum resistance to all elements",
     "maximum_resource": "maximum resource",

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ psutil
 pydantic
 pydantic-numpy
 pydantic-yaml
-
 pyinstaller
 pyqt6
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ pyyaml
 rapidfuzz
 ruff
 selenium
+seleniumbase
 tk
 typing_extensions
 webdriver-manager

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ psutil
 pydantic
 pydantic-numpy
 pydantic-yaml
+
 pyinstaller
 pyqt6
 pytest
@@ -28,6 +29,7 @@ pytweening
 pywin32
 pyyaml
 rapidfuzz
+ruamel.yaml==0.18.6
 ruff
 selenium
 seleniumbase

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@ import concurrent.futures
 
 TP = concurrent.futures.ThreadPoolExecutor()
 
-__version__ = "5.7.9"
+__version__ = "5.7.10"

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -50,6 +50,12 @@ class LogLevels(enum.StrEnum):
     critical = enum.auto()
 
 
+class UnfilteredUniquesType(enum.StrEnum):
+    favorite = enum.auto()
+    ignore = enum.auto()
+    junk = enum.auto()
+
+
 class ComparisonType(enum.StrEnum):
     larger = enum.auto()
     smaller = enum.auto()
@@ -234,6 +240,10 @@ class GeneralModel(_IniBaseModel):
         description="When using the import build feature, whether to use the full dump (e.g. contains all filter items) or not",
     )
     handle_rares: HandleRaresType = Field(default=HandleRaresType.filter, description="How to handle rares that the filter finds.")
+    handle_uniques: UnfilteredUniquesType = Field(
+        default=UnfilteredUniquesType.favorite,
+        description="What should be done with uniques that do not match any profile. Mythics are always favorited. If mark_as_favorite is unchecked then uniques that match a profile will not be favorited.",
+    )
     hidden_transparency: float = Field(
         default=0.35, description="Transparency of the overlay when not hovering it (has a 3 second delay after hovering)"
     )

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -145,6 +145,9 @@ class AspectUniqueFilterModel(AffixAspectFilterModel):
     def name_must_exist(cls, name: str) -> str:
         from src.dataloader import Dataloader  # This on module level would be a circular import, so we do it lazy for now
 
+        # Ensure name is in format we expect
+        name = name.lower().replace("'", "").replace(" ", "_").replace(",", "")
+
         if name not in Dataloader().aspect_unique_dict:
             raise ValueError(f"affix {name} does not exist")
         return name
@@ -454,9 +457,10 @@ class SigilFilterModel(BaseModel):
 
 class UniqueModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    affix: list[AffixFilterModel] = []
     aspect: AspectUniqueFilterModel = None
+    affix: list[AffixFilterModel] = []
     itemType: list[ItemType] = []
+    profileAlias: str = ""
     minGreaterAffixCount: int = 0
     minPower: int = 0
     mythic: bool = False

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -457,7 +457,7 @@ class SigilFilterModel(BaseModel):
 
 class UniqueModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    aspect: AspectUniqueFilterModel = None
+    aspect: AspectUniqueFilterModel = None  # Aspect needs to stay on top so the model is written how people expect
     affix: list[AffixFilterModel] = []
     itemType: list[ItemType] = []
     profileAlias: str = ""

--- a/src/gui/importer/common.py
+++ b/src/gui/importer/common.py
@@ -14,6 +14,7 @@ from selenium.webdriver.chromium.webdriver import ChromiumDriver
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.wait import WebDriverWait
+from seleniumbase import Driver
 
 from src import __version__
 from src.config.loader import IniConfigLoader
@@ -139,12 +140,12 @@ def match_to_enum(enum_class, target_string: str, check_keys: bool = False):
     return None
 
 
-def retry_importer(func=None, inject_webdriver: bool = False):
+def retry_importer(func=None, inject_webdriver: bool = False, uc=False):
     def decorator_retry_importer(wrap_function):
         @functools.wraps(wrap_function)
         def wrapper(*args, **kwargs):
             if inject_webdriver and "driver" not in kwargs and not args:
-                kwargs["driver"] = setup_webdriver()
+                kwargs["driver"] = setup_webdriver(uc=uc)
             for _ in range(5):
                 try:
                     res = wrap_function(*args, **kwargs)
@@ -180,7 +181,9 @@ def save_as_profile(file_name: str, profile: ProfileModel, url: str):
     LOGGER.info(f"Created profile {save_path}")
 
 
-def setup_webdriver() -> ChromiumDriver:
+def setup_webdriver(uc: bool = False) -> ChromiumDriver:
+    if uc:
+        return Driver(uc=uc, headless2=True)
     match IniConfigLoader().general.browser:
         case BrowserType.edge:
             options = webdriver.EdgeOptions()

--- a/src/gui/importer/common.py
+++ b/src/gui/importer/common.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from typing import Literal, TypeVar
 
 import httpx
-from pydantic_yaml import to_yaml_str
+from ruamel.yaml import YAML, StringIO
 from selenium import webdriver
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.chromium.webdriver import ChromiumDriver
@@ -171,14 +171,38 @@ def save_as_profile(file_name: str, profile: ProfileModel, url: str):
         file.write(f"# {url}\n")
         file.write(f"# {datetime.datetime.now(tz=datetime.UTC).strftime("%Y-%m-%d %H:%M:%S")} (v{__version__})\n")
         file.write(
-            to_yaml_str(
+            _to_yaml_str(
                 profile,
-                default_flow_style=None,
                 exclude_unset=not IniConfigLoader().general.full_dump,
-                exclude=["name", "Sigils", "Uniques"],
+                exclude={"name", "Sigils"},
             )
         )
     LOGGER.info(f"Created profile {save_path}")
+
+
+# Built in to_yaml_str does not preserve the order of the attributes of the model, which is important for uniques
+def _to_yaml_str(profile: ProfileModel, exclude_unset: bool, exclude: set[str]) -> str:
+    str_val = profile.model_dump_json(exclude_unset=exclude_unset, exclude=exclude)
+    yaml = YAML()
+    yaml.default_flow_style = None
+    dict_val = yaml.load(str_val)
+    _rm_style_info(dict_val)
+    stream = StringIO()
+    yaml.dump(dict_val, stream)
+    stream.seek(0)
+    return stream.read()
+
+
+def _rm_style_info(d):
+    if isinstance(d, dict):
+        d.fa._flow_style = None
+        for k, v in d.items():
+            _rm_style_info(k)
+            _rm_style_info(v)
+    elif isinstance(d, list):
+        d.fa._flow_style = None
+        for elem in d:
+            _rm_style_info(elem)
 
 
 def setup_webdriver(uc: bool = False) -> ChromiumDriver:

--- a/src/gui/importer/d4builds.py
+++ b/src/gui/importer/d4builds.py
@@ -114,7 +114,7 @@ def import_d4builds(url: str, driver: ChromiumDriver = None):
                 unique_model.aspect = AspectUniqueFilterModel(name=unique_name)
                 unique_model.affix = [AffixFilterModel(name=x.name) for x in affixes]
                 unique_filters.append(unique_model)
-            except:
+            except Exception:
                 LOGGER.exception(f"Unexpected error importing unique {unique_name}, please report a bug.")
             continue
 

--- a/src/gui/importer/d4builds.py
+++ b/src/gui/importer/d4builds.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import re
 import time
+import traceback
 
 import lxml.html
 from selenium.webdriver.chromium.webdriver import ChromiumDriver
@@ -10,7 +11,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
 import src.logger
-from src.config.models import AffixFilterCountModel, AffixFilterModel, ItemFilterModel, ProfileModel
+from src.config.models import AffixFilterCountModel, AffixFilterModel, AspectUniqueFilterModel, ItemFilterModel, ProfileModel, UniqueModel
 from src.dataloader import Dataloader
 from src.gui.importer.common import (
     fix_offhand_type,
@@ -33,6 +34,7 @@ ITEM_GROUP_XPATH = ".//*[contains(@class, 'builder__stats__group')]"
 ITEM_SLOT_XPATH = ".//*[contains(@class, 'builder__stats__slot')]"
 ITEM_STATS_XPATH = ".//*[contains(@class, 'dropdown__button__wrapper')]"
 PAPERDOLL_ITEM_SLOT_XPATH = ".//*[contains(@class, 'builder__gear__slot')]"
+PAPERDOLL_ITEM_UNIQUE_NAME_XPATH = ".//*[contains(@class, 'builder__gear__name--')]"
 PAPERDOLL_ITEM_XPATH = ".//*[contains(@class, 'builder__gear__item') and not(contains(@class, 'disabled'))]"
 PAPERDOLL_XPATH = "//*[contains(@class, 'builder__gear__items')]"
 TEMPERING_ICON_XPATH = ".//*[contains(@src, 'tempering_02.png')]"
@@ -63,15 +65,16 @@ def import_d4builds(url: str, driver: ChromiumDriver = None):
     if not (items := data.xpath(BUILD_OVERVIEW_XPATH)):
         LOGGER.error(msg := "No items found")
         raise D4BuildsException(msg)
-    non_unique_slots = _get_non_unique_slots(data=data)
+    slot_to_unique_name_map = _get_item_slots(data=data)
     finished_filters = []
+    unique_filters = []
     for item in items[0]:
         item_filter = ItemFilterModel()
         if not (slot := item.xpath(ITEM_SLOT_XPATH)[1].tail):
             LOGGER.error("No item_type found")
             continue
-        if slot not in non_unique_slots:
-            LOGGER.warning(f"Uniques or empty are not supported. Skipping: {slot}")
+        if slot not in slot_to_unique_name_map:
+            LOGGER.warning(f"Empty slots are not supported. Skipping: {slot}")
             continue
         if not (stats := item.xpath(ITEM_STATS_XPATH)):
             LOGGER.error(f"No stats found for {slot=}")
@@ -104,6 +107,19 @@ def import_d4builds(url: str, driver: ChromiumDriver = None):
                 inherents.append(affix_obj)
             else:
                 affixes.append(affix_obj)
+
+        if slot_to_unique_name_map[slot]:
+            unique_model = UniqueModel()
+            unique_name = slot_to_unique_name_map[slot]
+            try:
+                unique_model.aspect = AspectUniqueFilterModel(name=unique_name)
+                unique_model.affix = [AffixFilterModel(name=x.name) for x in affixes]
+                unique_filters.append(unique_model)
+            except Exception as e:
+                print(traceback.format_exc())
+                LOGGER.error(f"Unexpected error importing unique {unique_name}, please report a bug: {str(e)}")
+            continue
+
         item_type = (
             match_to_enum(enum_class=ItemType, target_string=re.sub(r"\d+", "", slot.replace(" ", ""))) if item_type is None else item_type
         )
@@ -127,7 +143,7 @@ def import_d4builds(url: str, driver: ChromiumDriver = None):
             filter_name = f"{filter_name_template}{i}"
             i += 1
         finished_filters.append({filter_name: item_filter})
-    profile = ProfileModel(name="imported profile", Affixes=sorted(finished_filters, key=lambda x: next(iter(x))))
+    profile = ProfileModel(name="imported profile", Affixes=sorted(finished_filters, key=lambda x: next(iter(x))), Uniques=unique_filters)
     save_as_profile(
         file_name=f"d4build_{class_name}_{datetime.datetime.now(tz=datetime.UTC).strftime("%Y_%m_%d_%H_%M_%S")}", profile=profile, url=url
     )
@@ -146,8 +162,8 @@ def _corrections(input_str: str) -> str:
     return input_str
 
 
-def _get_non_unique_slots(data: lxml.html.HtmlElement) -> list[str]:
-    result = []
+def _get_item_slots(data: lxml.html.HtmlElement) -> dict[str, str]:
+    result = {}
     if not (paperdoll := data.xpath(PAPERDOLL_XPATH)):
         LOGGER.error(msg := "No paperdoll found")
         raise D4BuildsException(msg)
@@ -155,9 +171,11 @@ def _get_non_unique_slots(data: lxml.html.HtmlElement) -> list[str]:
         LOGGER.error(msg := "No items found")
         raise D4BuildsException(msg)
     for item in items:
-        if not item.xpath(UNIQUE_ICON_XPATH):
-            slot = item.xpath(PAPERDOLL_ITEM_SLOT_XPATH)
-            result.append(slot[0].text)
+        slot = item.xpath(PAPERDOLL_ITEM_SLOT_XPATH)[0].text
+        if slot == "2H Weapon":  # This happens when a build has a weapon and no offhand
+            slot = "Weapon"
+        unique_name = item.xpath(PAPERDOLL_ITEM_UNIQUE_NAME_XPATH)
+        result[slot] = unique_name[0].text if unique_name else ""
     return result
 
 

--- a/src/gui/importer/d4builds.py
+++ b/src/gui/importer/d4builds.py
@@ -169,11 +169,12 @@ def _get_item_slots(data: lxml.html.HtmlElement) -> dict[str, str]:
         LOGGER.error(msg := "No items found")
         raise D4BuildsException(msg)
     for item in items:
-        slot = item.xpath(PAPERDOLL_ITEM_SLOT_XPATH)[0].text
-        if slot == "2H Weapon":  # This happens when a build has a weapon and no offhand
-            slot = "Weapon"
-        unique_name = item.xpath(PAPERDOLL_ITEM_UNIQUE_NAME_XPATH)
-        result[slot] = unique_name[0].text if unique_name else ""
+        if item.xpath(PAPERDOLL_ITEM_SLOT_XPATH):
+            slot = item.xpath(PAPERDOLL_ITEM_SLOT_XPATH)[0].text
+            if slot == "2H Weapon":  # This happens when a build has a weapon and no offhand
+                slot = "Weapon"
+            unique_name = item.xpath(PAPERDOLL_ITEM_UNIQUE_NAME_XPATH)
+            result[slot] = unique_name[0].text if unique_name else ""
     return result
 
 

--- a/src/gui/importer/d4builds.py
+++ b/src/gui/importer/d4builds.py
@@ -44,7 +44,7 @@ class D4BuildsException(Exception):
 
 
 @retry_importer(inject_webdriver=True)
-def import_d4builds(driver: ChromiumDriver = None, url: str = None):
+def import_d4builds(url: str, driver: ChromiumDriver = None):
     url = url.strip().replace("\n", "")
     if BASE_URL not in url:
         LOGGER.error("Invalid url, please use a d4builds url")

--- a/src/gui/importer/d4builds.py
+++ b/src/gui/importer/d4builds.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import re
 import time
-import traceback
 
 import lxml.html
 from selenium.webdriver.chromium.webdriver import ChromiumDriver
@@ -115,9 +114,8 @@ def import_d4builds(url: str, driver: ChromiumDriver = None):
                 unique_model.aspect = AspectUniqueFilterModel(name=unique_name)
                 unique_model.affix = [AffixFilterModel(name=x.name) for x in affixes]
                 unique_filters.append(unique_model)
-            except Exception as e:
-                print(traceback.format_exc())
-                LOGGER.error(f"Unexpected error importing unique {unique_name}, please report a bug: {str(e)}")
+            except:
+                LOGGER.exception(f"Unexpected error importing unique {unique_name}, please report a bug.")
             continue
 
         item_type = (

--- a/src/gui/importer/maxroll.py
+++ b/src/gui/importer/maxroll.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import re
-import traceback
 
 import lxml.html
 
@@ -67,9 +66,8 @@ def import_maxroll(url: str):
                     for x in _find_item_affixes(mapping_data=mapping_data, item_affixes=resolved_item["explicits"])
                 ]
                 unique_filters.append(unique_model)
-            except Exception as e:
-                print(traceback.format_exc())
-                LOGGER.error(f"Unexpected error importing unique {unique_name}, please report a bug: {str(e)}")
+            except:
+                LOGGER.exception(f"Unexpected error importing unique {unique_name}, please report a bug.")
             continue
         if (item_type := _find_item_type(mapping_data=mapping_data["items"], value=resolved_item["id"])) is None:
             LOGGER.error("Couldn't find item type")

--- a/src/gui/importer/maxroll.py
+++ b/src/gui/importer/maxroll.py
@@ -66,7 +66,7 @@ def import_maxroll(url: str):
                     for x in _find_item_affixes(mapping_data=mapping_data, item_affixes=resolved_item["explicits"])
                 ]
                 unique_filters.append(unique_model)
-            except:
+            except Exception:
                 LOGGER.exception(f"Unexpected error importing unique {unique_name}, please report a bug.")
             continue
         if (item_type := _find_item_type(mapping_data=mapping_data["items"], value=resolved_item["id"])) is None:

--- a/src/gui/importer/mobalytics.py
+++ b/src/gui/importer/mobalytics.py
@@ -1,11 +1,12 @@
 import logging
 import re
+import traceback
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import lxml.html
 
 import src.logger
-from src.config.models import AffixFilterCountModel, AffixFilterModel, ItemFilterModel, ProfileModel
+from src.config.models import AffixFilterCountModel, AffixFilterModel, AspectUniqueFilterModel, ItemFilterModel, ProfileModel, UniqueModel
 from src.dataloader import Dataloader
 from src.gui.importer.common import (
     fix_offhand_type,
@@ -66,6 +67,7 @@ def import_mobalytics(url: str):
         LOGGER.error(msg := "No items found")
         raise MobalyticsException(msg)
     finished_filters = []
+    unique_filters = []
     for item in items:
         item_filter = ItemFilterModel()
         if not (name := item.xpath(ITEM_NAME_XPATH)):
@@ -73,18 +75,20 @@ def import_mobalytics(url: str):
                 continue
             LOGGER.error(msg := "No item name found")
             raise MobalyticsException(msg)
-        if "aspect" not in (x := name[0].text).lower():
-            LOGGER.warning(f"Uniques are not supported. Skipping: {x}")
-            continue
         if not (slot_elem := item.xpath(IMAGE_XPATH)):
             LOGGER.error(msg := "No item_type found")
             raise MobalyticsException(msg)
         slot = slot_elem[0].attrib["alt"]
+        unique_name = name[0].text if "aspect" not in name[0].text.lower() else ""
         if not (stats := item.xpath(STATS_LIST_XPATH)):
             if item.xpath(ITEM_AFFIXES_EMPTY_XPATH):
-                continue
-            LOGGER.error(msg := "No stats found")
-            raise MobalyticsException(msg)
+                if unique_name:
+                    LOGGER.warning(f"Unique {unique_name} had no affixes listed for it, only the aspect will be imported.")
+                else:
+                    continue
+            else:
+                LOGGER.error(msg := "No stats found")
+                raise MobalyticsException(msg)
         item_type = None
         affixes = []
         inherents = []
@@ -109,6 +113,19 @@ def import_mobalytics(url: str):
                 inherents.append(affix_obj)
             else:
                 affixes.append(affix_obj)
+
+        if unique_name:
+            unique_model = UniqueModel()
+            try:
+                unique_model.aspect = AspectUniqueFilterModel(name=unique_name)
+                if affixes:
+                    unique_model.affix = [AffixFilterModel(name=x.name) for x in affixes]
+                unique_filters.append(unique_model)
+            except Exception as e:
+                print(traceback.format_exc())
+                LOGGER.error(f"Unexpected error importing unique {unique_name}, please report a bug: {str(e)}")
+            continue
+
         item_type = match_to_enum(enum_class=ItemType, target_string=re.sub(r"\d+", "", slot.lower())) if item_type is None else item_type
         if item_type is None:
             LOGGER.warning(f"Couldn't match item_type: {slot}. Please edit manually")
@@ -130,7 +147,7 @@ def import_mobalytics(url: str):
             filter_name = f"{filter_name_template}{i}"
             i += 1
         finished_filters.append({filter_name: item_filter})
-    profile = ProfileModel(name="imported profile", Affixes=sorted(finished_filters, key=lambda x: next(iter(x))))
+    profile = ProfileModel(name="imported profile", Affixes=sorted(finished_filters, key=lambda x: next(iter(x))), Uniques=unique_filters)
     build_name = build_name if build_name else f"{class_name}_{data.xpath(BUILD_GUIDE_ACTIVE_LOADOUT_XPATH)[0].text()}"
     save_as_profile(file_name=build_name, profile=profile, url=url)
     LOGGER.info("Finished")

--- a/src/gui/importer/mobalytics.py
+++ b/src/gui/importer/mobalytics.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import traceback
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import lxml.html
@@ -121,9 +120,8 @@ def import_mobalytics(url: str):
                 if affixes:
                     unique_model.affix = [AffixFilterModel(name=x.name) for x in affixes]
                 unique_filters.append(unique_model)
-            except Exception as e:
-                print(traceback.format_exc())
-                LOGGER.error(f"Unexpected error importing unique {unique_name}, please report a bug: {str(e)}")
+            except:
+                LOGGER.exception(f"Unexpected error importing unique {unique_name}, please report a bug.")
             continue
 
         item_type = match_to_enum(enum_class=ItemType, target_string=re.sub(r"\d+", "", slot.lower())) if item_type is None else item_type

--- a/src/gui/importer/mobalytics.py
+++ b/src/gui/importer/mobalytics.py
@@ -120,7 +120,7 @@ def import_mobalytics(url: str):
                 if affixes:
                     unique_model.affix = [AffixFilterModel(name=x.name) for x in affixes]
                 unique_filters.append(unique_model)
-            except:
+            except Exception:
                 LOGGER.exception(f"Unexpected error importing unique {unique_name}, please report a bug.")
             continue
 

--- a/src/item/filter.py
+++ b/src/item/filter.py
@@ -204,8 +204,19 @@ class Filter:
                     matched_full_name = f"{filter_item.profileAlias}.{item.aspect.name}"
                 res.matched.append(_MatchedFilter(matched_full_name, did_match_aspect=True))
         res.all_unique_filters_are_aspects = all_filters_are_aspect
-        if not res.keep and item.rarity == ItemRarity.Mythic:  # Always keep mythics no matter what
+
+        # Always keep mythics no matter what
+        # If all filters are for aspects specifically and none apply to this item, we default to handle_uniques config
+        if not res.keep and (
+            item.rarity == ItemRarity.Mythic
+            or (
+                res.all_unique_filters_are_aspects
+                and not res.unique_aspect_in_profile
+                and IniConfigLoader().general.handle_uniques != UnfilteredUniquesType.junk
+            )
+        ):
             res.keep = True
+
         return res
 
     def _did_files_change(self) -> bool:

--- a/src/loot_filter.py
+++ b/src/loot_filter.py
@@ -120,15 +120,13 @@ def check_items(inv: InventoryBase, force_refresh: ItemRefreshType):
         # property
         if item_descr.rarity == ItemRarity.Unique:
             if not res.keep:
+                _mark_as_junk()
+            elif res.keep:
                 if res.all_unique_filters_are_aspects and not res.unique_aspect_in_profile:
                     if IniConfigLoader().general.handle_uniques == UnfilteredUniquesType.favorite:
                         _mark_as_favorite()
-                    elif IniConfigLoader().general.handle_uniques == UnfilteredUniquesType.junk:
-                        _mark_as_junk()
-                else:
-                    _mark_as_junk()
-            elif res.keep and IniConfigLoader().general.mark_as_favorite:
-                _mark_as_favorite()
+                elif IniConfigLoader().general.mark_as_favorite:
+                    _mark_as_favorite()
         else:
             if not res.keep:
                 _mark_as_junk()

--- a/src/scripts/vision_mode.py
+++ b/src/scripts/vision_mode.py
@@ -10,7 +10,7 @@ import numpy as np
 import src.logger
 from src.cam import Cam
 from src.config.loader import IniConfigLoader
-from src.config.models import HandleRaresType
+from src.config.models import HandleRaresType, UnfilteredUniquesType
 from src.config.ui import ResManager
 from src.item.data.item_type import ItemType
 from src.item.data.rarity import ItemRarity
@@ -244,7 +244,14 @@ def vision_mode():
                 if item_descr is not None:
                     res = Filter().should_keep(item_descr)
                     if not res.keep:
-                        match = False
+                        if (
+                            item_descr.rarity == ItemRarity.Unique
+                            and res.all_unique_filters_are_aspects
+                            and not res.unique_aspect_in_profile
+                        ):
+                            match = IniConfigLoader().general.handle_uniques != UnfilteredUniquesType.junk
+                        else:
+                            match = False
 
                 # Adapt colors based on config
                 if match:

--- a/src/scripts/vision_mode.py
+++ b/src/scripts/vision_mode.py
@@ -10,7 +10,7 @@ import numpy as np
 import src.logger
 from src.cam import Cam
 from src.config.loader import IniConfigLoader
-from src.config.models import HandleRaresType, UnfilteredUniquesType
+from src.config.models import HandleRaresType
 from src.config.ui import ResManager
 from src.item.data.item_type import ItemType
 from src.item.data.rarity import ItemRarity
@@ -243,15 +243,7 @@ def vision_mode():
 
                 if item_descr is not None:
                     res = Filter().should_keep(item_descr)
-                    if not res.keep:
-                        if (
-                            item_descr.rarity == ItemRarity.Unique
-                            and res.all_unique_filters_are_aspects
-                            and not res.unique_aspect_in_profile
-                        ):
-                            match = IniConfigLoader().general.handle_uniques != UnfilteredUniquesType.junk
-                        else:
-                            match = False
+                    match = res.keep
 
                 # Adapt colors based on config
                 if match:

--- a/src/tools/data/custom_affixes_enUS.json
+++ b/src/tools/data/custom_affixes_enUS.json
@@ -5,6 +5,7 @@
 	"damage_reduction_from_enemies_affected_by_trap_skills": "damage reduction from enemies affected by trap skills",
 	"fire_damage_ranks_of_the_inner_flames_passive": "fire damage ranks of the inner flames passive",
 	"lucky_hit_up_to_a_chance_to_gain_damage_for_seconds": "lucky hit up to a chance to gain damage for seconds",
+	"maximum_poison_resistance": "maximum poison resistance",
 	"nature_magic_skill_cooldown_reduction": "nature magic skill cooldown reduction",
 	"rain_of_arrows_skill_cooldown_reduction": "rain of arrows skill cooldown reduction",
 	"rank_of_all_agility_skills": "rank of all agility skills",

--- a/tests/gui/importer/test_diablo_trade.py
+++ b/tests/gui/importer/test_diablo_trade.py
@@ -10,7 +10,7 @@ URLS = [
 
 
 @pytest.mark.parametrize("url", URLS)
-@pytest.mark.requests
+@pytest.mark.selenium
 def test_import_diablo_trade(url: str, mock_ini_loader: MockerFixture, mocker: MockerFixture):
     Dataloader()  # need to load data first or the mock will make it impossible
     mocker.patch("builtins.open", new=mocker.mock_open())

--- a/tests/item/filter/data/filters.py
+++ b/tests/item/filter/data/filters.py
@@ -151,6 +151,21 @@ affix = ProfileModel(
     ],
 )
 
+always_keep_mythics = ProfileModel(
+    name="keep_mythics",
+    Uniques=[
+        UniqueModel(minPower=900),
+    ],
+)
+
+aspect_only_unique_filters = ProfileModel(
+    name="aspect_only",
+    Uniques=[
+        UniqueModel(aspect=AspectUniqueFilterModel(name="tibaults_will"), minPower=900),
+        UniqueModel(aspect=AspectUniqueFilterModel(name="black_river"), minPower=900, profileAlias="alias_test"),
+    ],
+)
+
 sigil = ProfileModel(
     name="test",
     Sigils=SigilFilterModel(

--- a/tests/item/filter/data/uniques.py
+++ b/tests/item/filter/data/uniques.py
@@ -10,6 +10,18 @@ class TestUnique(Item):
         super().__init__(rarity=rarity, item_type=item_type, power=power, **kwargs)
 
 
+aspect_only_mythic_tests = [
+    ("matches filter", True, ["aspect_only.tibaults_will"], TestUnique(aspect=Aspect(name="tibaults_will"), power=925)),
+    ("does not match filter", False, [], TestUnique(aspect=Aspect(name="tibaults_will"), power=800)),
+    ("matches with alias", True, ["alias_test.black_river"], TestUnique(aspect=Aspect(name="black_river"), power=925)),
+    ("no aspect applies", True, [], TestUnique(aspect=Aspect("crown_of_lucion"))),
+]
+
+simple_mythics = [
+    ("matches filter", True, TestUnique(aspect=Aspect(name="black_river"), power=925, rarity=ItemRarity.Mythic)),
+    ("does not match but should keep", True, TestUnique(aspect=Aspect(name="black_river"), power=800, rarity=ItemRarity.Mythic)),
+]
+
 uniques = [
     ("item power too low", [], TestUnique(power=800)),
     ("wrong type", [], TestUnique(item_type=ItemType.Helm, aspect=Aspect(name="deathless_visage", value=1862))),

--- a/tests/item/filter/filter_test.py
+++ b/tests/item/filter/filter_test.py
@@ -8,7 +8,7 @@ from src.item.filter import Filter, _FilterResult
 from src.item.models import Item
 from tests.item.filter.data.affixes import affixes
 from tests.item.filter.data.sigils import sigil_jalal, sigil_priority, sigils
-from tests.item.filter.data.uniques import uniques
+from tests.item.filter.data.uniques import aspect_only_mythic_tests, simple_mythics, uniques
 
 
 def _create_mocked_filter(mocker: MockerFixture) -> Filter:
@@ -57,3 +57,23 @@ def test_uniques(name: str, result: list[str], item: Item, mocker: MockerFixture
     test_filter = _create_mocked_filter(mocker)
     test_filter.unique_filters = {filters.unique.name: filters.unique.Uniques}
     assert natsorted([match.profile for match in test_filter.should_keep(item).matched]) == natsorted(result)
+
+
+@pytest.mark.parametrize(("name", "result", "item"), natsorted(simple_mythics), ids=[name for name, _, _ in natsorted(simple_mythics)])
+def test_mythic_always_kept(name: str, result: bool, item: Item, mocker: MockerFixture):
+    test_filter = _create_mocked_filter(mocker)
+    test_filter.unique_filters = {filters.always_keep_mythics.name: filters.always_keep_mythics.Uniques}
+    assert test_filter.should_keep(item).keep == result
+
+
+@pytest.mark.parametrize(
+    ("name", "should_keep", "matched", "item"),
+    natsorted(aspect_only_mythic_tests),
+    ids=[name for name, _, _, _ in natsorted(aspect_only_mythic_tests)],
+)
+def test_unfiltered_unique_is_kept(name: str, should_keep: bool, matched: list[str], item: Item, mocker: MockerFixture):
+    test_filter = _create_mocked_filter(mocker)
+    test_filter.unique_filters = {filters.aspect_only_unique_filters.name: filters.aspect_only_unique_filters.Uniques}
+    test_filter_result = test_filter.should_keep(item)
+    assert natsorted([match.profile for match in test_filter_result.matched]) == natsorted(matched)
+    assert test_filter_result.keep == should_keep


### PR DESCRIPTION
Uniques are now handled in two ways that I think make sense in practice but is hard to explain.

Let's say we have a tibault's will with 900 item power.

If we only have this in our profiles:

```
Uniques:
- aspect: {name: tibaults_will}
  minPower: 925
```

Then naturally the Tibault's marked as junk. If we change minPower to 875, it will be favorited. That functionality has not changed.

If we also have a Crown of Lucion in our inventory, it matches no unique filters. What happens to it now is configurable through the new handle_uniques property, which defaults to favorite.

If instead our filter looks like this:

```
Uniques:
- aspect: {name: tibaults_will}
  minPower: 925
- itemType: [pants]
```
Now there is a filter that applies to everything as itemType is a global filter. Our Tibault's Will will be marked as favorite because it matches the second filter (the item type one). Crown of Lucion will be marked as junk because it matches neither filter. handle_uniques no longer applies because there is now a filter that applies to every single item.

What this has allowed me to do is add unique importing to the importers because having aspect-only filters now doesn't junk uniques outside of that aspect with the default configurations. I don't think people will use the global filters very often, but they continue to be supported if needed.