### PR TITLE
(BugFix) another fix for galvanic azurite, using unicode for nbsp

### DIFF
--- a/assets/lang/enUS/corrections.json
+++ b/assets/lang/enUS/corrections.json
@@ -1,8 +1,8 @@
 {
     "bad_tts_uniques": {
         "bane_ofahjad-den": "bane_of_ahjad-den",
-        "galvanic\u00a0azurite": "galvanic_azurite",
         "galvanicazurite": "galvanic_azurite",
+        "galvanic azurite": "galvanic_azurite",
         "kilt_ofblackwing": "kilt_of_blackwing",
         "mjￃﾖlnic_ryng": "mjölnic_ryng",
         "sunstainedwar-crozier": "sunstained_war-crozier"

--- a/src/scripts/vision_mode_fast.py
+++ b/src/scripts/vision_mode_fast.py
@@ -7,9 +7,9 @@ from tkinter.font import Font
 import src.item.descr.read_descr_tts
 import src.logger
 import src.tts
+from src.cam import Cam
 from src.config.helper import singleton
 from src.config.loader import IniConfigLoader
-from src.cam import Cam
 from src.config.ui import ResManager
 from src.item.data.rarity import ItemRarity
 from src.item.filter import Filter, MatchedFilter
@@ -67,11 +67,11 @@ class VisionModeFast:
         minimum_font = Font(family="Courier New", size=minimum_font_size)
         self.textbox = tk.Text(self.root, bg="black", wrap=tk.WORD, borderwidth=0, highlightthickness=0, font=minimum_font)
         if IniConfigLoader().general.vision_mode_coordinates is None:
-            x=ResManager().resolution[0] / 2
-            y=ResManager().resolution[2] / 5
+            x = ResManager().resolution[0] / 2
+            y = ResManager().resolution[2] / 5
         else:
-            x=IniConfigLoader().general.vision_mode_coordinates[0]
-            y=IniConfigLoader().general.vision_mode_coordinates[1]
+            x = IniConfigLoader().general.vision_mode_coordinates[0]
+            y = IniConfigLoader().general.vision_mode_coordinates[1]
         self.textbox.place(x=x, y=y)
         self.textbox.config(state=tk.DISABLED)
 


### PR DESCRIPTION
another fix for unique 'galvanic azurite'. 

Tested locally on my client with the item, and seems to work.

issue: https://github.com/d4lfteam/d4lf/issues/578