### PR TITLE
mobalytics fix

### DIFF
--- a/src/gui/importer/mobalytics.py
+++ b/src/gui/importer/mobalytics.py
@@ -1,8 +1,9 @@
 import json
 import logging
 import re
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 
+import httpx
 import jsonpath
 import lxml.html
 
@@ -37,8 +38,125 @@ from src.scripts import correct_name
 LOGGER = logging.getLogger(__name__)
 LOGGER.propagate = True
 BUILD_GUIDE_BASE_URL = "https://mobalytics.gg/diablo-4/"
+MOBALYTICS_GRAPHQL_URL = "https://mobalytics.gg/api/diablo-4/v1/graphql/query"
 SCRIPT_XPATH = "//script"
 BUILD_SCRIPT_PREFIX = "window.__PRELOADED_STATE__="
+PROFILE_BUILD_PATH_REGEX = re.compile(r"/diablo-4/profile/(?P<author>[^/]+)/builds/(?P<document>[^/?#]+)")
+UUID_REGEX = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
+
+DOCUMENT_BY_ID_QUERY = """
+query D4LFDocumentById($input: Diablo4UserGeneratedDocumentInputById!) {
+  game: diablo4 {
+    documents {
+      userGeneratedDocumentById(input: $input) {
+        error
+        data {
+          id
+          slugifiedName
+          tags { data { groupSlug slug name } }
+          data {
+            ... on Diablo4UserGeneratedDocumentData {
+              name
+              childrenIds
+              buildVariants {
+                values {
+                  id
+                  genericBuilder {
+                    slots {
+                      gameSlotSlug
+                      gameEntity {
+                        type
+                        modifiers {
+                          gearStats { id isGreater isMasterwork }
+                          implicitStats { id }
+                        }
+                        entity {
+                          ... on D4Aspect { __typename iconUrl title: name }
+                          ... on D4UniqueItem { __typename iconUrl title: name chaos mythic }
+                          ... on D4ChaosPerk { __typename iconUrl title: name rarity }
+                        }
+                      }
+                    }
+                  }
+                  paragon {
+                    nodes { slug }
+                    boards {
+                      x
+                      y
+                      rotation
+                      board { slug }
+                      glyph { slug }
+                      glyphLevel
+                    }
+                    priorityList { iconURL slug type }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+DOCUMENT_BY_SLUGIFIED_NAME_QUERY = """
+query D4LFDocumentBySlugifiedName($input: NgfUserGeneratedDocumentInputBySlugifiedName!) {
+  game: diablo4 {
+    documents {
+      userGeneratedDocumentBySlugifiedName(input: $input) {
+        error
+        data {
+          id
+          slugifiedName
+          tags { data { groupSlug slug name } }
+          data {
+            ... on Diablo4UserGeneratedDocumentData {
+              name
+              childrenIds
+              buildVariants {
+                values {
+                  id
+                  genericBuilder {
+                    slots {
+                      gameSlotSlug
+                      gameEntity {
+                        type
+                        modifiers {
+                          gearStats { id isGreater isMasterwork }
+                          implicitStats { id }
+                        }
+                        entity {
+                          ... on D4Aspect { __typename iconUrl title: name }
+                          ... on D4UniqueItem { __typename iconUrl title: name chaos mythic }
+                          ... on D4ChaosPerk { __typename iconUrl title: name rarity }
+                        }
+                      }
+                    }
+                  }
+                  paragon {
+                    nodes { slug }
+                    boards {
+                      x
+                      y
+                      rotation
+                      board { slug }
+                      glyph { slug }
+                      glyphLevel
+                    }
+                    priorityList { iconURL slug type }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
 
 
 class MobalyticsException(Exception):
@@ -75,16 +193,19 @@ def import_mobalytics(config: ImportConfig):
         )
         raise MobalyticsException(msg)
 
+    document = _get_mobalytics_document(full_script_data_json, url)
+    if not document:
+        LOGGER.error(msg := "No Mobalytics build data was found.")
+        raise MobalyticsException(msg)
+
     # Get the JSON block that contains the build and its variants
-    build_data = dict(jsonpath.findall("$..userGeneratedDocumentBySlug.data.data", full_script_data_json)[0])
-    season_number = _extract_mobalytics_season_number(full_script_data_json)
+    build_data = dict(document["data"])
+    season_number = _extract_mobalytics_season_number(document)
     build_header = build_data["name"]
     if not build_header:
         LOGGER.error(msg := "No build name found")
         raise MobalyticsException(msg)
-    class_name = jsonpath.findall(
-        "$..userGeneratedDocumentBySlug.data.tags.data[?@.groupSlug=='class'].name", full_script_data_json
-    )[0].lower()
+    class_name = _get_mobalytics_tag_name(document, "class").lower()
     if not class_name:
         LOGGER.error(msg := "No class name found")
         raise MobalyticsException(msg)
@@ -94,7 +215,9 @@ def import_mobalytics(config: ImportConfig):
         items = jsonpath.findall("$..buildVariants.values[0].genericBuilder.slots", build_data)[0]
         variant_id = jsonpath.findall("$..buildVariants.values[0].id", build_data)[0]
 
-    paragon_data = jsonpath.findall(f"$..buildVariants.values[?@.id=='{variant_id}'].paragon", build_data)[0]
+    paragon_data = {}
+    if paragon_matches := jsonpath.findall(f"$..buildVariants.values[?@.id=='{variant_id}'].paragon", build_data):
+        paragon_data = paragon_matches[0]
 
     variant_name = jsonpath.findall(f"$..childrenVariants[?@.id=='{variant_id}'].title", full_script_data_json)
     variant_name = variant_name[0] if variant_name else ""
@@ -189,6 +312,10 @@ def import_mobalytics(config: ImportConfig):
         affixes = _convert_raw_to_affixes(raw_affixes, config.import_greater_affixes)
         inherents = _convert_raw_to_affixes(raw_inherents)
 
+        if not affixes:
+            LOGGER.debug(f"Skipping {slot_type} because it had no importable affixes.")
+            continue
+
         item_filter.affixPool = [
             AffixFilterCountModel(
                 count=[AffixFilterModel(name=x.name, want_greater=x.type == AffixType.greater) for x in affixes],
@@ -248,8 +375,67 @@ def _fix_input_url(url: str) -> str:
     return unquote(url)
 
 
-def _extract_mobalytics_season_number(full_script_data_json: dict) -> str:
-    tag_names = jsonpath.findall("$..userGeneratedDocumentBySlug.data.tags.data[*].name", full_script_data_json)
+def _get_mobalytics_document(full_script_data_json: dict, url: str) -> dict | None:
+    document_matches = jsonpath.findall("$..userGeneratedDocumentBySlug.data", full_script_data_json)
+    if document_matches:
+        return document_matches[0]
+
+    document_matches = jsonpath.findall("$..userGeneratedDocumentBySlugifiedName.data", full_script_data_json)
+    if document_matches:
+        return document_matches[0]
+
+    document_matches = jsonpath.findall("$..userGeneratedDocumentById.data", full_script_data_json)
+    if document_matches:
+        return document_matches[0]
+
+    return _fetch_mobalytics_document(url)
+
+
+def _fetch_mobalytics_document(url: str) -> dict | None:
+    profile_match = PROFILE_BUILD_PATH_REGEX.search(urlparse(url).path)
+    if not profile_match:
+        return None
+
+    document_identifier = profile_match.group("document")
+    if UUID_REGEX.fullmatch(document_identifier):
+        query = DOCUMENT_BY_ID_QUERY
+        variables = {"input": {"id": document_identifier}}
+        response_key = "userGeneratedDocumentById"
+    else:
+        query = DOCUMENT_BY_SLUGIFIED_NAME_QUERY
+        variables = {
+            "input": {"authorProfileName": profile_match.group("author"), "slugifiedName": document_identifier}
+        }
+        response_key = "userGeneratedDocumentBySlugifiedName"
+
+    try:
+        response = httpx.post(MOBALYTICS_GRAPHQL_URL, json={"query": query, "variables": variables}, timeout=20)
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        LOGGER.exception(msg := "Couldn't get Mobalytics profile build data")
+        raise MobalyticsException(msg) from exc
+
+    payload = response.json()
+    if payload.get("errors"):
+        LOGGER.error(msg := f"Mobalytics returned GraphQL errors: {payload['errors']}")
+        raise MobalyticsException(msg)
+
+    document = payload.get("data", {}).get("game", {}).get("documents", {}).get(response_key, {})
+    if document.get("error"):
+        LOGGER.error(msg := f"Mobalytics returned document error: {document['error']}")
+        raise MobalyticsException(msg)
+    return document.get("data")
+
+
+def _get_mobalytics_tag_name(document: dict, group_slug: str) -> str:
+    for tag in document.get("tags", {}).get("data", []):
+        if tag.get("groupSlug") == group_slug:
+            return str(tag.get("name") or "")
+    return ""
+
+
+def _extract_mobalytics_season_number(document: dict) -> str:
+    tag_names = [str(tag.get("name") or "") for tag in document.get("tags", {}).get("data", [])]
     for tag_name in tag_names:
         if season_match := re.search(r"\bSeason\s+(\d+)\b", str(tag_name), flags=re.IGNORECASE):
             season_number = season_match.group(1)

--- a/src/scripts/common.py
+++ b/src/scripts/common.py
@@ -6,8 +6,6 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from item.data.seasonal_attribute import SeasonalAttribute
-
 if TYPE_CHECKING:
     from tkinter import Canvas
 
@@ -19,6 +17,7 @@ from src.config.loader import IniConfigLoader
 from src.config.models import JunkRaresType
 from src.item.data.item_type import ItemType, is_consumable, is_non_sigil_mapping, is_socketable
 from src.item.data.rarity import ItemRarity
+from src.item.data.seasonal_attribute import SeasonalAttribute
 from src.utils.custom_mouse import mouse
 
 try:

--- a/src/scripts/vision_mode_with_highlighting.py
+++ b/src/scripts/vision_mode_with_highlighting.py
@@ -12,8 +12,8 @@ import numpy as np
 
 import src.item.descr.read_descr_tts
 import src.tts
-from config.helper import singleton
 from src.cam import Cam
+from src.config.helper import singleton
 from src.config.loader import IniConfigLoader
 from src.config.ui import ResManager
 from src.item.data.item_type import is_sigil

--- a/src/template_finder.py
+++ b/src/template_finder.py
@@ -13,7 +13,7 @@ from src.config.ui import ResManager
 from src.utils.image_operations import alpha_to_mask, color_filter, crop
 from src.utils.misc import run_until_condition
 from src.utils.roi_operations import get_center
-from utils.window import screenshot
+from src.utils.window import screenshot
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/gui/importer/test_mobalytics.py
+++ b/tests/gui/importer/test_mobalytics.py
@@ -1,5 +1,7 @@
+import json
 import os
 import typing
+from types import SimpleNamespace
 
 import pytest
 
@@ -43,3 +45,168 @@ def test_import_mobalytics(url: str, mock_ini_loader: MockerFixture, mocker: Moc
         custom_file_name=None,
     )
     import_mobalytics(config=config)
+
+
+def test_import_mobalytics_skips_slots_without_importable_affixes(mocker: MockerFixture) -> None:
+    build_data = {
+        "name": "Profane Sentinel Warlock Endgame Build Guide",
+        "buildVariants": {
+            "values": [
+                {
+                    "id": "variant-1",
+                    "genericBuilder": {
+                        "slots": [
+                            {
+                                "gameEntity": {
+                                    "type": "aspects",
+                                    "entity": {"title": "Legendary Helm"},
+                                    "modifiers": {"gearStats": [], "implicitStats": [{"id": "2h-sword"}]},
+                                },
+                                "gameSlotSlug": "weapon",
+                            }
+                        ]
+                    },
+                    "paragon": {},
+                }
+            ]
+        },
+    }
+    preloaded_state = {
+        "userGeneratedDocumentBySlug": {
+            "data": {
+                "data": build_data,
+                "tags": {
+                    "data": [{"groupSlug": "class", "name": "Warlock"}, {"groupSlug": "season", "name": "Season 13"}]
+                },
+            }
+        },
+        "childrenVariants": [],
+    }
+    html = f"<html><script>window.__PRELOADED_STATE__={json.dumps(preloaded_state)};</script></html>"
+    mocker.patch("src.gui.importer.mobalytics.get_with_retry", return_value=SimpleNamespace(text=html))
+    save_profile_mock = mocker.patch("src.gui.importer.mobalytics.save_as_profile", return_value="imported")
+
+    config = ImportConfig(
+        url="https://mobalytics.gg/diablo-4/builds/warlock-profane-sentinel-endgame",
+        import_uniques=True,
+        import_aspect_upgrades=True,
+        add_to_profiles=False,
+        import_greater_affixes=True,
+        require_greater_affixes=True,
+        custom_file_name=None,
+    )
+
+    import_mobalytics(config=config)
+
+    save_profile_mock.assert_called_once()
+    profile = save_profile_mock.call_args.kwargs["profile"]
+    assert profile.Affixes == []
+
+
+def test_import_mobalytics_loads_profile_build_by_id_when_preloaded_state_is_empty(mocker: MockerFixture) -> None:
+    html = (
+        "<html><script>window.__PRELOADED_STATE__="
+        '{"diablo4State":{"apollo":{"graphqlV2":{"queries":[]}}}};'
+        "</script></html>"
+    )
+    mobalytics_payload = {
+        "data": {
+            "game": {
+                "documents": {
+                    "userGeneratedDocumentById": {
+                        "error": None,
+                        "data": {
+                            "id": "df95afa9-619e-4dc6-b5b6-0405830695be",
+                            "slugifiedName": "ancient-leap",
+                            "tags": {
+                                "data": [
+                                    {"groupSlug": "class", "slug": "barbarian", "name": "Barbarian"},
+                                    {"groupSlug": "season", "slug": "season-13", "name": "Season 13"},
+                                ]
+                            },
+                            "data": {
+                                "name": "Ancient Leap",
+                                "childrenIds": ["root"],
+                                "buildVariants": {
+                                    "values": [
+                                        {
+                                            "id": "2",
+                                            "genericBuilder": {
+                                                "slots": [
+                                                    {
+                                                        "gameSlotSlug": "chest-armor",
+                                                        "gameEntity": {
+                                                            "type": "aspects",
+                                                            "entity": {"title": "Battle Fervor's Aspect"},
+                                                            "modifiers": {
+                                                                "gearStats": [
+                                                                    {"id": "strength", "isGreater": False},
+                                                                    {"id": "maximum-life", "isGreater": False},
+                                                                    {"id": "fury-per-second", "isGreater": False},
+                                                                    {"id": "ranks-to-rallying-cry", "isGreater": True},
+                                                                ],
+                                                                "implicitStats": [None],
+                                                            },
+                                                        },
+                                                    }
+                                                ]
+                                            },
+                                            "paragon": {
+                                                "boards": [
+                                                    {
+                                                        "x": 0,
+                                                        "y": 0,
+                                                        "rotation": 0,
+                                                        "board": {"slug": "barbarian-starter-board"},
+                                                        "glyph": {"slug": "barbarian-marshal"},
+                                                        "glyphLevel": 100,
+                                                    }
+                                                ],
+                                                "nodes": [{"slug": "barbarian-starter-board-x1-y1"}],
+                                                "priorityList": [],
+                                            },
+                                        }
+                                    ]
+                                },
+                            },
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+    class MockResponse:
+        def raise_for_status(self) -> None:
+            return
+
+        def json(self) -> dict:
+            return mobalytics_payload
+
+    mocker.patch("src.gui.importer.mobalytics.get_with_retry", return_value=SimpleNamespace(text=html))
+    post_mock = mocker.patch("src.gui.importer.mobalytics.httpx.post", return_value=MockResponse())
+    save_profile_mock = mocker.patch("src.gui.importer.mobalytics.save_as_profile", return_value="imported")
+
+    config = ImportConfig(
+        url="https://mobalytics.gg/diablo-4/profile/cliptis/builds/df95afa9-619e-4dc6-b5b6-0405830695be",
+        import_uniques=True,
+        import_aspect_upgrades=True,
+        add_to_profiles=False,
+        import_greater_affixes=True,
+        require_greater_affixes=True,
+        export_paragon=True,
+        custom_file_name=None,
+    )
+
+    import_mobalytics(config=config)
+
+    post_mock.assert_called_once()
+    query = post_mock.call_args.kwargs["json"]["query"]
+    assert "paragon" in query
+    profile = save_profile_mock.call_args.kwargs["profile"]
+    assert len(profile.Affixes) == 1
+    item_filter = next(iter(profile.Affixes[0].root.values()))
+    assert item_filter.minGreaterAffixCount == 1
+    assert profile.Paragon is not None
+    assert profile.Paragon["ParagonBoardsList"][0][0]["Name"] == "barbarian-starting-board"
+    assert profile.Paragon["ParagonBoardsList"][0][0]["Glyph"] == "barbarian-marshal"


### PR DESCRIPTION
Root cause: Mobalytics profile build pages can ship an empty __PRELOADED_STATE__, so the importer could not find userGeneratedDocumentBySlug and failed before parsing build data. The new fallback initially loaded equipment data only, so Paragon export still had no buildVariants.values[].paragon data.

Code change: Added a Mobalytics GraphQL fallback for profile build URLs by ID or slugified name, reusing the existing import flow once the document is loaded. The fallback now also requests Paragon nodes, boards, and priorityList. Empty affix slots are skipped before creating AffixFilterCountModel.

Impact: Existing preloaded-state imports still use the same parser path. Profile URL imports now support equipment affixes and Paragon export when Mobalytics returns Paragon data.