### PR TITLE
Fixed D4Builds weapon item type import

### DIFF
--- a/src/gui/importer/d4builds.py
+++ b/src/gui/importer/d4builds.py
@@ -4,6 +4,8 @@ import time
 from typing import TYPE_CHECKING
 
 import lxml.html
+from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
@@ -56,12 +58,67 @@ ITEM_SLOT_XPATH = ".//*[contains(@class, 'builder__stats__slot')]"
 ITEM_STATS_XPATH = ".//*[contains(@class, 'dropdown__button__wrapper')]"
 GA_XPATH = ".//*[contains(@class, 'greater__affix__button--filled')]"
 PAPERDOLL_ITEM_SLOT_XPATH = ".//*[contains(@class, 'builder__gear__slot')]"
+PAPERDOLL_ITEM_NAME_XPATH = ".//*[contains(@class, 'builder__gear__name')]"
 PAPERDOLL_ITEM_UNIQUE_NAME_XPATH = ".//*[contains(@class, 'builder__gear__name--')]"
-PAPERDOLL_ITEM_XPATH = ".//*[contains(@class, 'builder__gear__item') and not(contains(@class, 'disabled'))]"
+PAPERDOLL_ITEM_XPATH = (
+    ".//*[contains(concat(' ', normalize-space(@class), ' '), ' builder__gear__item ') "
+    "and not(contains(concat(' ', normalize-space(@class), ' '), ' disabled '))]"
+)
+PAPERDOLL_ITEM_TOOLTIP_TARGET_XPATH = (
+    ".//*[contains(concat(' ', normalize-space(@class), ' '), ' builder__gear__icon__wrapper ') "
+    "or contains(concat(' ', normalize-space(@class), ' '), ' builder__gear__icon ')]"
+)
 PAPERDOLL_LEGENDARY_ASPECT_XPATH = (
     "//*[@class='builder__gear__name' and not(contains(@class, 'builder__gear__name--'))]"
 )
 PAPERDOLL_XPATH = "//*[contains(@class, 'builder__gear__items')]"
+VISIBLE_TOOLTIP_TEXT_SCRIPT = """
+const expectedText = String(arguments[0] || '').trim().toLowerCase();
+const tooltipSelector = '[class*="tooltip"], [role="tooltip"]';
+const isVisible = (element) => {
+    const style = window.getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return style.display !== 'none'
+        && style.visibility !== 'hidden'
+        && style.opacity !== '0'
+        && rect.width > 0
+        && rect.height > 0;
+};
+const isTopLevelTooltip = (element) => {
+    const parentTooltip = element.parentElement ? element.parentElement.closest(tooltipSelector) : null;
+    return parentTooltip === null;
+};
+const tooltipTexts = Array.from(document.querySelectorAll(tooltipSelector))
+    .filter(isVisible)
+    .filter(isTopLevelTooltip)
+    .map((element) => element.innerText || element.textContent || '')
+    .filter(Boolean)
+    .map((text) => text.trim());
+return tooltipTexts
+    .filter((text) => !expectedText || text.toLowerCase().includes(expectedText))
+    .join(' ');
+"""
+HOVER_ELEMENT_SCRIPT = """
+arguments[0].scrollIntoView({block: 'center', inline: 'center'});
+const rect = arguments[0].getBoundingClientRect();
+const eventOptions = {
+    bubbles: true,
+    cancelable: true,
+    view: window,
+    clientX: rect.left + rect.width / 2,
+    clientY: rect.top + rect.height / 2,
+};
+if (window.PointerEvent) {
+    for (const eventName of ['pointerover', 'pointerenter', 'pointermove']) {
+        arguments[0].dispatchEvent(new PointerEvent(eventName, eventOptions));
+    }
+}
+for (const eventName of ['mouseover', 'mouseenter', 'mousemove']) {
+    arguments[0].dispatchEvent(new MouseEvent(eventName, eventOptions));
+}
+"""
+TOOLTIP_READ_ATTEMPTS = 5
+TOOLTIP_READ_SLEEP_SECONDS = 0.2
 TEMPERING_ICON_XPATH = ".//*[contains(@src, 'tempering_02.png')]"
 SANCTIFIED_ICON_XPATH = ".//*[contains(@src, 'sanctified_icon.png')]"
 UNIQUE_ICON_XPATH = ".//*[contains(@src, '/Uniques/')]"
@@ -92,6 +149,7 @@ def import_d4builds(config: ImportConfig, driver: ChromiumDriver = None):
         LOGGER.error(msg := "No items found")
         raise D4BuildsException(msg)
     slot_to_unique_name_map = _get_item_slots(data=data)
+    slot_to_item_type_map = _get_item_types_from_paperdoll_tooltips(driver=driver)
     finished_filters = []
     unique_filters = []
     aspect_upgrade_filters = _get_legendary_aspects(data=data)
@@ -100,13 +158,14 @@ def import_d4builds(config: ImportConfig, driver: ChromiumDriver = None):
         if not (slot := item.xpath(ITEM_SLOT_XPATH)[1].tail):
             LOGGER.error("No item_type found")
             continue
+        slot = _normalize_slot_name(slot)
         if slot not in slot_to_unique_name_map:
             LOGGER.warning(f"Empty slots are not supported. Skipping: {slot}")
             continue
         if not (stats := item.xpath(ITEM_STATS_XPATH)):
             LOGGER.error(f"No stats found for {slot=}")
             continue
-        item_type = None
+        item_type = slot_to_item_type_map.get(slot)
         affixes = []
         inherents = []
 
@@ -124,18 +183,20 @@ def import_d4builds(config: ImportConfig, driver: ChromiumDriver = None):
                 )
             continue
 
-        is_weapon = "weapon" in slot.lower()
+        is_weapon = _is_weapon_slot(slot)
+        if is_weapon and item_type is None:
+            item_type = fix_weapon_type(input_str=" ".join(item.text_content().split()))
         for stat in stats:
             if stat.xpath(TEMPERING_ICON_XPATH) or stat.xpath(SANCTIFIED_ICON_XPATH):
                 continue
-            if "filled" not in stat.xpath("../..")[0].attrib["class"]:
-                continue
             affix_name = _get_affix_name(stat)
-            if not affix_name:
-                LOGGER.warning(f"Slot {slot} is missing an affix, skipping import of that affix.")
-                continue
             if is_weapon and (x := fix_weapon_type(input_str=affix_name)) is not None:
                 item_type = x
+                continue
+            if "filled" not in stat.xpath("../..")[0].attrib["class"]:
+                continue
+            if not affix_name:
+                LOGGER.warning(f"Slot {slot} is missing an affix, skipping import of that affix.")
                 continue
             if (
                 "offhand" in slot.lower()
@@ -186,14 +247,14 @@ def import_d4builds(config: ImportConfig, driver: ChromiumDriver = None):
         update_mingreateraffixcount(item_filter, config.require_greater_affixes)
         if inherents:
             item_filter.inherentPool = [AffixFilterCountModel(count=[AffixFilterModel(name=x.name) for x in inherents])]
-        filter_name_template = item_filter.itemType[0].name if item_type else slot.replace(" ", "")
+        filter_name_template = slot.replace(" ", "") if is_weapon or item_type is None else item_filter.itemType[0].name
         filter_name = filter_name_template
         i = 2
         while any(filter_name == next(iter(x)) for x in finished_filters):
             filter_name = f"{filter_name_template}{i}"
             i += 1
         finished_filters.append({filter_name: item_filter})
-    profile = ProfileModel(name="imported profile", Affixes=sorted(finished_filters, key=lambda x: next(iter(x))))
+    profile = ProfileModel(name="imported profile", Affixes=finished_filters)
     if config.import_uniques and unique_filters:
         profile.Uniques = unique_filters
     if config.import_aspect_upgrades and aspect_upgrade_filters:
@@ -267,6 +328,68 @@ def _extract_d4builds_season_number(data: lxml.html.HtmlElement) -> str:
     return ""
 
 
+def _normalize_slot_name(slot: str | None) -> str:
+    slot = " ".join(str(slot or "").split())
+    if slot == "2H Weapon":  # This happens when a build has a weapon and no offhand
+        return "Weapon"
+    return slot
+
+
+def _is_weapon_slot(slot: str) -> bool:
+    return "weapon" in slot.casefold()
+
+
+def _get_item_types_from_paperdoll_tooltips(driver: ChromiumDriver) -> dict[str, ItemType]:
+    result = {}
+    items = driver.find_elements(By.XPATH, f"{PAPERDOLL_XPATH}{PAPERDOLL_ITEM_XPATH.removeprefix('.')}")
+    for item in items:
+        try:
+            slot_elements = item.find_elements(By.XPATH, PAPERDOLL_ITEM_SLOT_XPATH)
+            if not slot_elements:
+                continue
+            slot = _normalize_slot_name(slot_elements[0].text)
+            if not _is_weapon_slot(slot):
+                continue
+            item_type = fix_weapon_type(input_str=" ".join(item.text.split()))
+            if item_type is None:
+                tooltip_text = _get_item_tooltip_text(driver=driver, item=item, slot=slot)
+                item_type = fix_weapon_type(input_str=" ".join(tooltip_text.split()))
+            if item_type is not None:
+                result[slot] = item_type
+        except WebDriverException:
+            LOGGER.debug("Could not inspect D4Builds paperdoll item tooltip.", exc_info=True)
+    return result
+
+
+def _get_item_tooltip_text(driver: ChromiumDriver, item, slot: str) -> str:
+    expected_text = _get_paperdoll_item_name(item=item, slot=slot)
+    hover_targets = [*item.find_elements(By.XPATH, PAPERDOLL_ITEM_TOOLTIP_TARGET_XPATH), item]
+    for hover_target in hover_targets:
+        driver.execute_script(HOVER_ELEMENT_SCRIPT, hover_target)
+        ActionChains(driver).move_to_element(hover_target).perform()
+        tooltip_text = _get_visible_tooltip_text(driver=driver, expected_text=expected_text)
+        if tooltip_text:
+            return tooltip_text
+    return ""
+
+
+def _get_paperdoll_item_name(item, slot: str) -> str:
+    for name_element in item.find_elements(By.XPATH, PAPERDOLL_ITEM_NAME_XPATH):
+        item_name = " ".join(name_element.text.split())
+        if item_name and item_name != slot:
+            return item_name
+    return " ".join(item.text.replace(slot, "").split())
+
+
+def _get_visible_tooltip_text(driver: ChromiumDriver, expected_text: str) -> str:
+    for _ in range(TOOLTIP_READ_ATTEMPTS):
+        tooltip_text = " ".join(str(driver.execute_script(VISIBLE_TOOLTIP_TEXT_SCRIPT, expected_text) or "").split())
+        if tooltip_text:
+            return tooltip_text
+        time.sleep(TOOLTIP_READ_SLEEP_SECONDS)
+    return ""
+
+
 def _get_item_slots(data: lxml.html.HtmlElement) -> dict[str, str]:
     result = {}
     if not (paperdoll := data.xpath(PAPERDOLL_XPATH)):
@@ -277,9 +400,7 @@ def _get_item_slots(data: lxml.html.HtmlElement) -> dict[str, str]:
         raise D4BuildsException(msg)
     for item in items:
         if item.xpath(PAPERDOLL_ITEM_SLOT_XPATH):
-            slot = item.xpath(PAPERDOLL_ITEM_SLOT_XPATH)[0].text
-            if slot == "2H Weapon":  # This happens when a build has a weapon and no offhand
-                slot = "Weapon"
+            slot = _normalize_slot_name(item.xpath(PAPERDOLL_ITEM_SLOT_XPATH)[0].text)
             unique_name = item.xpath(PAPERDOLL_ITEM_UNIQUE_NAME_XPATH)
             result[slot] = unique_name[0].text if unique_name else ""
     return result

--- a/src/scripts/common.py
+++ b/src/scripts/common.py
@@ -6,8 +6,6 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from item.data.seasonal_attribute import SeasonalAttribute
-
 if TYPE_CHECKING:
     from tkinter import Canvas
 
@@ -19,6 +17,7 @@ from src.config.loader import IniConfigLoader
 from src.config.models import JunkRaresType
 from src.item.data.item_type import ItemType, is_consumable, is_non_sigil_mapping, is_socketable
 from src.item.data.rarity import ItemRarity
+from src.item.data.seasonal_attribute import SeasonalAttribute
 from src.utils.custom_mouse import mouse
 
 try:

--- a/src/scripts/vision_mode_with_highlighting.py
+++ b/src/scripts/vision_mode_with_highlighting.py
@@ -12,8 +12,8 @@ import numpy as np
 
 import src.item.descr.read_descr_tts
 import src.tts
-from config.helper import singleton
 from src.cam import Cam
+from src.config.helper import singleton
 from src.config.loader import IniConfigLoader
 from src.config.ui import ResManager
 from src.item.data.item_type import is_sigil

--- a/src/template_finder.py
+++ b/src/template_finder.py
@@ -13,7 +13,7 @@ from src.config.ui import ResManager
 from src.utils.image_operations import alpha_to_mask, color_filter, crop
 from src.utils.misc import run_until_condition
 from src.utils.roi_operations import get_center
-from utils.window import screenshot
+from src.utils.window import screenshot
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/gui/importer/test_d4builds.py
+++ b/tests/gui/importer/test_d4builds.py
@@ -5,8 +5,19 @@ import lxml.html
 import pytest
 
 from src.dataloader import Dataloader
-from src.gui.importer.d4builds import _extract_build_metadata, _extract_d4builds_season_number, import_d4builds
+from src.gui.importer.d4builds import (
+    PAPERDOLL_ITEM_NAME_XPATH,
+    PAPERDOLL_ITEM_SLOT_XPATH,
+    PAPERDOLL_ITEM_TOOLTIP_TARGET_XPATH,
+    VISIBLE_TOOLTIP_TEXT_SCRIPT,
+    _extract_build_metadata,
+    _extract_d4builds_season_number,
+    _get_item_slots,
+    _get_item_types_from_paperdoll_tooltips,
+    import_d4builds,
+)
 from src.gui.importer.importer_config import ImportConfig
+from src.item.data.item_type import ItemType
 
 if typing.TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -101,6 +112,214 @@ def test_extract_d4builds_season_number_from_gear_dropdown() -> None:
     """)
 
     assert _extract_d4builds_season_number(data) == "12"
+
+
+def test_get_item_slots_extracts_unique_name_only() -> None:
+    data = lxml.html.fromstring("""
+        <div class="builder__gear__items">
+            <div class="builder__gear__item">
+                <div class="builder__gear__slot">Bludgeoning Weapon</div>
+                <div class="builder__gear__name">Heavy Hitting Aspect</div>
+            </div>
+        </div>
+    """)
+
+    item_slots = _get_item_slots(data=data)
+
+    assert not item_slots["Bludgeoning Weapon"]
+
+
+def test_import_d4builds_reads_weapon_type_from_unfilled_stat(mocker: MockerFixture) -> None:
+    Dataloader()
+    html = """
+        <div class="builder__header__name">Whirlwind Barbarian Endgame Build Guide - Diablo 4</div>
+        <div class="builder__gear">
+            <div class="builder__dropdown__wrapper">
+                <div class="dropdown">
+                    <div class="dropdown__button">Season 9</div>
+                </div>
+            </div>
+            <div class="builder__gear__items">
+                <div class="builder__gear__item">
+                    <div class="builder__gear__slot">Bludgeoning Weapon</div>
+                    <div class="builder__gear__name">Heavy Hitting Aspect</div>
+                </div>
+            </div>
+        </div>
+        <div class="builder__stats__list">
+            <div class="builder__stats__group">
+                <span class="builder__stats__slot"></span>
+                <span class="builder__stats__slot"></span>Bludgeoning Weapon
+                <div class="builder__stats__type">
+                    <span>2h Mace: 392.7% Overpower Damage</span>
+                </div>
+                <div class="builder__stats__affix">
+                    <div>
+                        <div class="dropdown__button__wrapper">
+                            <span></span>
+                        </div>
+                    </div>
+                </div>
+                <div class="builder__stats__affix filled">
+                    <div>
+                        <div class="dropdown__button__wrapper">
+                            <span>Strength</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="builder__stats__affix filled">
+                    <div>
+                        <div class="dropdown__button__wrapper">
+                            <span>Critical Strike Chance</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    """
+    driver = mocker.Mock(page_source=html)
+    driver.find_elements.return_value = []
+    wait = mocker.Mock()
+    wait.until.return_value = True
+    mocker.patch("src.gui.importer.d4builds.WebDriverWait", return_value=wait)
+    save_as_profile_mock = mocker.patch("src.gui.importer.d4builds.save_as_profile", return_value="profile")
+    config = ImportConfig(
+        url="https://d4builds.gg/builds/whirlwind-barbarian-endgame/?var=4",
+        import_uniques=True,
+        import_aspect_upgrades=False,
+        add_to_profiles=False,
+        import_greater_affixes=False,
+        require_greater_affixes=False,
+        custom_file_name="test",
+    )
+
+    import_d4builds(config=config, driver=driver)
+
+    profile = save_as_profile_mock.call_args.kwargs["profile"]
+    assert next(iter(profile.Affixes[0].root)) == "BludgeoningWeapon"
+    item_filter = next(iter(profile.Affixes[0].root.values()))
+    assert item_filter.itemType == [ItemType.Mace2H]
+
+
+def test_import_d4builds_preserves_weapon_type_from_tooltip_map(mocker: MockerFixture) -> None:
+    Dataloader()
+    html = """
+        <div class="builder__header__name">Whirlwind Barbarian Endgame Build Guide - Diablo 4</div>
+        <div class="builder__gear">
+            <div class="builder__dropdown__wrapper">
+                <div class="dropdown">
+                    <div class="dropdown__button">Season 9</div>
+                </div>
+            </div>
+            <div class="builder__gear__items">
+                <div class="builder__gear__item">
+                    <div class="builder__gear__slot">Boots</div>
+                    <div class="builder__gear__name">Aspect of Anger Management</div>
+                </div>
+                <div class="builder__gear__item">
+                    <div class="builder__gear__slot">Bludgeoning Weapon</div>
+                    <div class="builder__gear__name">Heavy Hitting Aspect</div>
+                </div>
+            </div>
+        </div>
+        <div class="builder__stats__list">
+            <div class="builder__stats__group">
+                <span class="builder__stats__slot"></span>
+                <span class="builder__stats__slot"></span>Boots
+                <div class="builder__stats__affix filled">
+                    <div>
+                        <div class="dropdown__button__wrapper">
+                            <span>Strength</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="builder__stats__affix filled">
+                    <div>
+                        <div class="dropdown__button__wrapper">
+                            <span>Movement Speed</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="builder__stats__group">
+                <span class="builder__stats__slot"></span>
+                <span class="builder__stats__slot"></span>Bludgeoning Weapon
+                <div class="builder__stats__affix filled">
+                    <div>
+                        <div class="dropdown__button__wrapper">
+                            <span>Strength</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="builder__stats__affix filled">
+                    <div>
+                        <div class="dropdown__button__wrapper">
+                            <span>Critical Strike Chance</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    """
+    driver = mocker.Mock(page_source=html)
+    wait = mocker.Mock()
+    wait.until.return_value = True
+    mocker.patch("src.gui.importer.d4builds.WebDriverWait", return_value=wait)
+    mocker.patch(
+        "src.gui.importer.d4builds._get_item_types_from_paperdoll_tooltips",
+        return_value={"Bludgeoning Weapon": ItemType.Mace2H},
+    )
+    save_as_profile_mock = mocker.patch("src.gui.importer.d4builds.save_as_profile", return_value="profile")
+    config = ImportConfig(
+        url="https://d4builds.gg/builds/whirlwind-barbarian-endgame/?var=4",
+        import_uniques=True,
+        import_aspect_upgrades=False,
+        add_to_profiles=False,
+        import_greater_affixes=False,
+        require_greater_affixes=False,
+        custom_file_name="test",
+    )
+
+    import_d4builds(config=config, driver=driver)
+
+    profile = save_as_profile_mock.call_args.kwargs["profile"]
+    assert [next(iter(affix_filter.root)) for affix_filter in profile.Affixes] == ["Boots", "BludgeoningWeapon"]
+    item_filter = next(iter(profile.Affixes[1].root.values()))
+    assert item_filter.itemType == [ItemType.Mace2H]
+
+
+def test_get_item_types_from_paperdoll_tooltips_reads_visible_tooltip(mocker: MockerFixture) -> None:
+    slot_element = mocker.Mock(text="Bludgeoning Weapon")
+    name_element = mocker.Mock(text="Heavy Hitting Aspect")
+    item_without_slot = mocker.Mock(text="builder gear item child")
+    item_without_slot.find_elements.return_value = []
+    hover_element = mocker.Mock()
+    item = mocker.Mock(text="Heavy Hitting Aspect")
+
+    def find_item_elements(_by: str, value: str) -> list[object]:
+        if value == PAPERDOLL_ITEM_SLOT_XPATH:
+            return [slot_element]
+        if value == PAPERDOLL_ITEM_NAME_XPATH:
+            return [name_element]
+        if value == PAPERDOLL_ITEM_TOOLTIP_TARGET_XPATH:
+            return [hover_element]
+        return []
+
+    item.find_elements.side_effect = find_item_elements
+    driver = mocker.Mock()
+    driver.find_elements.return_value = [item_without_slot, item]
+    driver.execute_script.return_value = "2h Mace: 392.7% Overpower Damage"
+    actions = mocker.Mock()
+    actions.move_to_element.return_value = actions
+    mocker.patch("src.gui.importer.d4builds.ActionChains", return_value=actions)
+    mocker.patch("src.gui.importer.d4builds.time.sleep")
+
+    item_types = _get_item_types_from_paperdoll_tooltips(driver=driver)
+
+    assert item_types["Bludgeoning Weapon"] == ItemType.Mace2H
+    driver.execute_script.assert_any_call(VISIBLE_TOOLTIP_TEXT_SCRIPT, "Heavy Hitting Aspect")
+    actions.move_to_element.assert_called_once_with(hover_element)
+    actions.perform.assert_called_once()
 
 
 @pytest.mark.parametrize("url", URLS)


### PR DESCRIPTION
Fixed D4Builds weapon item type import after their tooltip/layout change.

Changes:

D4Builds weapon item types are now read from the live paperdoll hover tooltip when static stats do not expose them. Tooltip matching is scoped to the current paperdoll item name to avoid stale tooltip text from another slot. Weapon filter keys now keep the D4Builds slot names, e.g. BludgeoningWeapon, Dual-WieldWeapon1, SlashingWeapon, while itemType is set to the detected concrete type like two-handed mace, mace, or polearm. D4Builds Affix filter order now preserves the source order instead of sorting alphabetically. Added focused D4Builds importer tests for tooltip item type detection, weapon filter naming, and source-order preservation.