### PR TITLE
profile editor update for s13

### DIFF
--- a/src/gui/profile_editor/affixes_tab.py
+++ b/src/gui/profile_editor/affixes_tab.py
@@ -9,6 +9,7 @@ from PyQt6.QtWidgets import (
     QDialog,
     QFormLayout,
     QFrame,
+    QGroupBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
@@ -25,7 +26,13 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from src.config.profile_models import AffixFilterCountModel, AffixFilterModel, ComparisonType, DynamicItemFilterModel
+from src.config.profile_models import (
+    AffixFilterCountModel,
+    AffixFilterModel,
+    AspectUniqueFilterModel,
+    ComparisonType,
+    DynamicItemFilterModel,
+)
 from src.dataloader import Dataloader
 from src.gui.collapsible_widget import Container
 from src.gui.dialog import (
@@ -131,6 +138,7 @@ class AffixGroupEditor(QWidget):
         general_form.addRow("Min Greater Affixes:", min_greater_layout)
 
         self.content_layout.addLayout(general_form)
+        self.create_unique_aspect_groupbox()
 
         pool_btn_layout = QHBoxLayout()
         add_affix_pool_btn = QPushButton("Add Affix Pool")
@@ -168,9 +176,158 @@ class AffixGroupEditor(QWidget):
         QTimer.singleShot(100, self.affix_pool_container.expand)
         QTimer.singleShot(100, self.inherent_pool_container.expand)
 
+    def create_unique_aspect_groupbox(self):
+        self.unique_aspect_groupbox = QGroupBox("Unique Aspect")
+        self.unique_aspect_form = QFormLayout()
+
+        self.unique_aspect_enabled = QCheckBox("Match unique aspect")
+        self.unique_aspect_enabled.setChecked(self.config.uniqueAspect is not None)
+        self.unique_aspect_enabled.stateChanged.connect(self.toggle_unique_aspect)
+        self.unique_aspect_form.addRow("Enabled:", self.unique_aspect_enabled)
+
+        self.unique_aspect_name_combo = IgnoreScrollWheelComboBox()
+        self.unique_aspect_name_combo.setEditable(True)
+        self.unique_aspect_name_combo.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
+        self.unique_aspect_name_combo.completer().setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
+        self.unique_aspect_name_combo.completer().setFilterMode(Qt.MatchFlag.MatchContains)
+        self.unique_aspect_name_combo.addItems(sorted(Dataloader().aspect_unique_dict.keys()))
+        if self.config.uniqueAspect is not None:
+            self.unique_aspect_name_combo.setCurrentText(self.config.uniqueAspect.name)
+        else:
+            self.unique_aspect_name_combo.setCurrentText("")
+        self.unique_aspect_name_combo.setMinimumWidth(400)
+        self.unique_aspect_name_combo.currentTextChanged.connect(self.update_unique_aspect_name)
+        self.unique_aspect_form.addRow("Name:", self.unique_aspect_name_combo)
+
+        self.unique_aspect_mode_combo = IgnoreScrollWheelComboBox()
+        self.unique_aspect_mode_combo.setFixedSize(100, self.unique_aspect_mode_combo.sizeHint().height())
+        self.unique_aspect_mode_combo.addItems([AFFIX_VALUE_MODE, AFFIX_PERCENT_MODE])
+        if self.config.uniqueAspect is not None and self.config.uniqueAspect.minPercentOfAspect:
+            self.unique_aspect_mode_combo.setCurrentText(AFFIX_PERCENT_MODE)
+        else:
+            self.unique_aspect_mode_combo.setCurrentText(AFFIX_VALUE_MODE)
+        self.unique_aspect_mode_combo.currentTextChanged.connect(self.update_unique_aspect_mode)
+        self.unique_aspect_form.addRow("Mode:", self.unique_aspect_mode_combo)
+
+        self.unique_aspect_value_edit = QLineEdit()
+        self.unique_aspect_value_edit.setFixedSize(100, self.unique_aspect_value_edit.sizeHint().height())
+        self.unique_aspect_value_edit.textChanged.connect(self.update_unique_aspect_value)
+        self.unique_aspect_form.addRow("Threshold:", self.unique_aspect_value_edit)
+
+        self.unique_aspect_comparison_combo = IgnoreScrollWheelComboBox()
+        self.unique_aspect_comparison_combo.setEditable(True)
+        self.unique_aspect_comparison_combo.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
+        self.unique_aspect_comparison_combo.completer().setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
+        self.unique_aspect_comparison_combo.setFixedSize(100, self.unique_aspect_comparison_combo.sizeHint().height())
+        self.unique_aspect_comparison_combo.addItems([ct.value for ct in ComparisonType])
+        if self.config.uniqueAspect is not None:
+            self.unique_aspect_comparison_combo.setCurrentText(self.config.uniqueAspect.comparison.value)
+        self.unique_aspect_comparison_combo.currentTextChanged.connect(self.update_unique_aspect_comparison)
+        self.unique_aspect_form.addRow("Comparison:", self.unique_aspect_comparison_combo)
+
+        self.unique_aspect_groupbox.setLayout(self.unique_aspect_form)
+        self.content_layout.addWidget(self.unique_aspect_groupbox)
+        self.refresh_unique_aspect_value_input()
+        self.set_unique_aspect_controls_enabled()
+
     def _refresh_widget_style(self, widget):
         widget.style().unpolish(widget)
         widget.style().polish(widget)
+
+    def set_unique_aspect_controls_enabled(self):
+        enabled = self.config.uniqueAspect is not None
+        self.unique_aspect_name_combo.setEnabled(True)
+        self.unique_aspect_mode_combo.setEnabled(enabled)
+        self.unique_aspect_value_edit.setEnabled(enabled)
+        self.unique_aspect_comparison_combo.setEnabled(
+            enabled and self.unique_aspect_mode_combo.currentText() == AFFIX_VALUE_MODE
+        )
+
+    def toggle_unique_aspect(self):
+        if self.unique_aspect_enabled.isChecked():
+            if self.config.uniqueAspect is None:
+                aspect_name = self.unique_aspect_name_combo.currentText()
+                if aspect_name not in Dataloader().aspect_unique_dict:
+                    aspect_name = min(Dataloader().aspect_unique_dict)
+                    self.unique_aspect_name_combo.setCurrentText(aspect_name)
+                self.config.uniqueAspect = AspectUniqueFilterModel(name=aspect_name)
+        else:
+            self.config.uniqueAspect = None
+
+        self.refresh_unique_aspect_value_input()
+        self.set_unique_aspect_controls_enabled()
+
+    def update_unique_aspect_name(self, current_text=None):
+        if self.config.uniqueAspect is None:
+            return
+        aspect_name = current_text or self.unique_aspect_name_combo.currentText()
+        if aspect_name not in Dataloader().aspect_unique_dict:
+            return
+        self.config.uniqueAspect.name = aspect_name
+
+    def refresh_unique_aspect_value_input(self):
+        self.unique_aspect_value_edit.blockSignals(True)
+        if self.config.uniqueAspect is None:
+            self.unique_aspect_value_edit.setText("")
+            self.unique_aspect_value_edit.setPlaceholderText("Value (optional)")
+            self.unique_aspect_value_edit.setValidator(QDoubleValidator(self.unique_aspect_value_edit))
+        elif self.unique_aspect_mode_combo.currentText() == AFFIX_PERCENT_MODE:
+            self.unique_aspect_value_edit.setPlaceholderText("Percent (0-100)")
+            self.unique_aspect_value_edit.setValidator(QIntValidator(0, 100, self.unique_aspect_value_edit))
+            display_value = (
+                ""
+                if self.config.uniqueAspect.minPercentOfAspect == 0
+                else str(self.config.uniqueAspect.minPercentOfAspect)
+            )
+            self.unique_aspect_value_edit.setText(display_value)
+        else:
+            self.unique_aspect_value_edit.setPlaceholderText("Value (optional)")
+            self.unique_aspect_value_edit.setValidator(QDoubleValidator(self.unique_aspect_value_edit))
+            display_value = "" if self.config.uniqueAspect.value is None else str(self.config.uniqueAspect.value)
+            self.unique_aspect_value_edit.setText(display_value)
+        self.unique_aspect_value_edit.blockSignals(False)
+
+    def update_unique_aspect_mode(self, current_text=None):
+        if self.config.uniqueAspect is None:
+            self.set_unique_aspect_controls_enabled()
+            return
+        mode = current_text or self.unique_aspect_mode_combo.currentText()
+        if mode == AFFIX_PERCENT_MODE:
+            self.config.uniqueAspect.value = None
+        else:
+            self.config.uniqueAspect.minPercentOfAspect = 0
+        self.refresh_unique_aspect_value_input()
+        self.set_unique_aspect_controls_enabled()
+
+    def update_unique_aspect_value(self, value):
+        if self.config.uniqueAspect is None:
+            return
+        if self.unique_aspect_mode_combo.currentText() == AFFIX_PERCENT_MODE:
+            try:
+                percent = int(value) if value else 0
+            except ValueError:
+                return
+            if not 0 <= percent <= 100:
+                QMessageBox.warning(self, "Warning", "Min % must be between 0 and 100.")
+                self.refresh_unique_aspect_value_input()
+                return
+            self.config.uniqueAspect.minPercentOfAspect = percent
+            self.config.uniqueAspect.value = None
+            return
+
+        try:
+            self.config.uniqueAspect.value = float(value) if value else None
+        except ValueError:
+            return
+        self.config.uniqueAspect.minPercentOfAspect = 0
+
+    def update_unique_aspect_comparison(self, current_text=None):
+        if self.config.uniqueAspect is None:
+            return
+        comparison = current_text or self.unique_aspect_comparison_combo.currentText()
+        if comparison not in {comparison_type.value for comparison_type in ComparisonType}:
+            return
+        self.config.uniqueAspect.comparison = ComparisonType(comparison)
 
     def init_affix_pool(self):
         """Initialize affix pool content on first expansion."""
@@ -221,7 +378,7 @@ class AffixGroupEditor(QWidget):
         )
 
         new_pool = AffixFilterCountModel(count=[default_affix], minCount=1, maxCount=3)
-        self.config.affixPool.append(new_pool)
+        self.config.inherentPool.append(new_pool)
         self.add_affix_pool_item(new_pool, True)
 
     def remove_selected(self, layout_widget: QVBoxLayout, inherent: bool = False):

--- a/src/gui/profile_editor/uniques_tab.py
+++ b/src/gui/profile_editor/uniques_tab.py
@@ -1,17 +1,10 @@
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
-    QCheckBox,
-    QComboBox,
-    QCompleter,
     QDialog,
     QFormLayout,
     QFrame,
     QGroupBox,
-    QHBoxLayout,
     QLineEdit,
-    QListWidget,
-    QListWidgetItem,
-    QMessageBox,
     QPushButton,
     QScrollArea,
     QTabWidget,
@@ -21,17 +14,8 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from src.config.profile_models import AffixFilterModel, AspectUniqueFilterModel, ComparisonType, GlobalUniqueModel
-from src.dataloader import Dataloader
-from src.gui.dialog import (
-    DeleteItem,
-    IgnoreScrollWheelComboBox,
-    IgnoreScrollWheelSpinBox,
-    MinGreaterDialog,
-    MinPowerDialog,
-)
-from src.gui.profile_editor.affixes_tab import AffixWidget
-from src.item.data.item_type import ItemType, is_armor, is_jewelry, is_weapon
+from src.config.profile_models import GlobalUniqueModel
+from src.gui.dialog import DeleteItem, IgnoreScrollWheelSpinBox, MinGreaterDialog, MinPercentDialog, MinPowerDialog
 
 UNIQUES_TABNAME = "Uniques"
 
@@ -47,20 +31,13 @@ class UniqueWidget(QWidget):
         scroll_area = QScrollArea(self)
         scroll_area.setWidgetResizable(True)
         scroll_area.setFrameShape(QFrame.Shape.NoFrame)
-        # Content widget that will hold all our existing UI elements
+
         content_widget = QWidget()
         self.content_layout = QVBoxLayout(content_widget)
         self.content_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
         self.create_general_groupbox()
 
-        if self.unique_model.aspect:
-            self.create_aspect_groupbox()
-
-        if self.unique_model.affix != []:
-            self.create_affix_groupbox()
-
-        # Set up scroll area
         scroll_area.setWidget(content_widget)
         self.main_layout = QVBoxLayout()
         self.main_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
@@ -68,154 +45,42 @@ class UniqueWidget(QWidget):
         self.setLayout(self.main_layout)
 
     def create_general_groupbox(self):
-        # General Settings
         self.general_groupbox = QGroupBox()
-        self.general_groupbox.setTitle("General Infos")
+        self.general_groupbox.setTitle("Global Unique Rule")
         self.general_form = QFormLayout()
 
-        self.create_item_type_combobox()
+        self.profile_alias = QLineEdit()
+        self.profile_alias.setMaximumWidth(300)
+        self.profile_alias.setText(self.unique_model.profileAlias)
+        self.profile_alias.textChanged.connect(self.update_profile_alias)
+        self.general_form.addRow("Profile Alias:", self.profile_alias)
 
         self.min_power = IgnoreScrollWheelSpinBox()
-        self.min_power.setMaximum(800)
+        self.min_power.setRange(0, 800)
         self.min_power.setValue(self.unique_model.minPower)
         self.min_power.setMaximumWidth(150)
         self.min_power.valueChanged.connect(self.update_min_power)
         self.general_form.addRow("Minimum Power:", self.min_power)
 
         self.min_greater = IgnoreScrollWheelSpinBox()
+        self.min_greater.setRange(0, 4)
         self.min_greater.setValue(self.unique_model.minGreaterAffixCount)
         self.min_greater.setMaximumWidth(150)
         self.min_greater.valueChanged.connect(self.update_min_greater_affix)
         self.general_form.addRow("Min Greater Affixes:", self.min_greater)
 
         self.min_percent = IgnoreScrollWheelSpinBox()
+        self.min_percent.setRange(0, 100)
         self.min_percent.setValue(self.unique_model.minPercentOfAspect)
-        self.min_percent.setMaximum(100)
         self.min_percent.setMaximumWidth(150)
         self.min_percent.valueChanged.connect(self.update_min_percent)
         self.general_form.addRow("Min Percent of Aspect:", self.min_percent)
 
-        self.mythic = QCheckBox(" ")
-        self.mythic.checkStateChanged.connect(self.update_mythic)
-        self.general_form.addRow("Mythic:", self.mythic)
         self.general_groupbox.setLayout(self.general_form)
         self.content_layout.addWidget(self.general_groupbox)
 
-    def create_item_type_combobox(self):
-        self.item_type_combo = IgnoreScrollWheelComboBox()
-        self.item_type_combo.setEditable(True)
-        self.item_type_combo.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
-        self.item_type_combo.completer().setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
-        item_types_names = [
-            item.name for item in ItemType.__members__.values() if is_armor(item) or is_jewelry(item) or is_weapon(item)
-        ]
-        item_types_names.append("None")
-        self.item_type_combo.addItems(item_types_names)
-        if len(self.unique_model.itemType) == 0:
-            self.item_type_combo.setCurrentText("None")
-        else:
-            self.item_type_combo.setCurrentText(self.unique_model.itemType[0].name)
-        self.item_type_combo.setMaximumWidth(150)
-        self.item_type_combo.currentIndexChanged.connect(self.update_item_type)
-        self.general_form.addRow("Item Type:", self.item_type_combo)
-
-    def create_aspect_groupbox(self):
-        # Aspect settings
-        self.unique_aspect_groupbox = QGroupBox()
-        self.unique_aspect_groupbox.setTitle("Aspect")
-        self.unique_aspect_form = QFormLayout()
-        self.unique_aspect_groupbox.setMinimumWidth(900)
-
-        self.aspect_name_combo = IgnoreScrollWheelComboBox()
-        self.aspect_name_combo.setEditable(True)
-
-        self.aspect_name_combo.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
-        self.aspect_name_combo.completer().setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
-        self.aspect_name_combo.addItems(sorted(Dataloader().aspect_unique_dict.keys()))
-        self.aspect_name_combo.setCurrentText(self.unique_model.aspect.name)
-        self.aspect_name_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
-        self.aspect_name_combo.setMinimumWidth(600)
-        self.aspect_name_combo.currentIndexChanged.connect(self.update_aspect_name)
-        self.unique_aspect_form.addRow("Name:", self.aspect_name_combo)
-
-        # Value Input
-        self.aspect_value_edit = QLineEdit()
-        self.aspect_value_edit.setMaximumWidth(100)
-        self.aspect_value_edit.setPlaceholderText("Value (optional)")
-        if self.unique_model.aspect.value is not None:
-            self.aspect_value_edit.setText(str(self.unique_model.aspect.value))
-        self.aspect_value_edit.textChanged.connect(self.update_aspect_value)
-        self.unique_model.aspect.value = self.unique_model.aspect.value
-        self.unique_aspect_form.addRow("Value:", self.aspect_value_edit)
-        # Comparison Combobox
-        self.comparison_combo = IgnoreScrollWheelComboBox()
-        self.comparison_combo.setEditable(True)
-        self.comparison_combo.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
-        self.comparison_combo.completer().setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
-        self.comparison_combo.setMaximumWidth(100)
-        self.comparison_combo.addItems([ct.value for ct in ComparisonType])
-        self.comparison_combo.setCurrentText(self.unique_model.aspect.comparison.value)
-        self.comparison_combo.currentIndexChanged.connect(self.update_aspect_comparison)
-        self.unique_model.aspect.comparison = ComparisonType(self.unique_model.aspect.comparison.value)
-        self.unique_aspect_form.addRow("Comparison:", self.comparison_combo)
-        self.unique_aspect_groupbox.setLayout(self.unique_aspect_form)
-        self.content_layout.insertWidget(1, self.unique_aspect_groupbox)
-        # self.content_layout.addWidget(self.unique_aspect_groupbox)
-
-    def remove_aspect_groupbox(self):
-        self.unique_aspect_groupbox.setParent(None)
-
-    def create_affix_groupbox(self):
-        self.affix_groupbox = QGroupBox()
-        self.affix_groupbox.setTitle("Affixes")
-        self.affix_groupbox_layout = QVBoxLayout()
-
-        self.affix_list = QListWidget()
-        self.affix_list.setMinimumHeight(200)
-        self.affix_list.setAlternatingRowColors(True)
-        for affix in self.unique_model.affix:
-            self.add_affix_item(affix)
-
-        affix_btn_layout = QHBoxLayout()
-        add_affix_btn = QPushButton("Add Affix")
-        add_affix_btn.clicked.connect(self.add_affix)
-        affix_btn_layout.addWidget(add_affix_btn)
-        remove_affix_btn = QPushButton("Remove Affix")
-        remove_affix_btn.clicked.connect(self.remove_affix)
-        affix_btn_layout.addWidget(remove_affix_btn)
-        self.affix_groupbox_layout.addLayout(affix_btn_layout)
-        self.affix_groupbox_layout.addWidget(self.affix_list)
-        self.affix_groupbox.setLayout(self.affix_groupbox_layout)
-        self.content_layout.addWidget(self.affix_groupbox)
-
-    def remove_affix_groupbox(self):
-        self.affix_groupbox.setParent(None)
-
-    def add_affix_item(self, affix: AffixFilterModel):
-        item = QListWidgetItem()
-        widget = AffixWidget(affix)
-        item.setSizeHint(widget.sizeHint())
-        self.affix_list.addItem(item)
-        self.affix_list.setItemWidget(item, widget)
-
-    def add_affix(self):
-        new_affix = AffixFilterModel(
-            name=next(iter(Dataloader().affix_dict.keys())), value=None, comparison=ComparisonType.larger
-        )
-        self.unique_model.affix.append(new_affix)
-        self.add_affix_item(new_affix)
-
-    def remove_affix(self):
-        for item in self.affix_list.selectedItems():
-            row = self.affix_list.row(item)
-            self.affix_list.takeItem(row)
-            del self.unique_model.affix[row]
-
-    def update_item_type(self):
-        if self.item_type_combo.currentText() == "None":
-            self.unique_model.itemType = []
-        else:
-            self.unique_model.itemType = [ItemType(ItemType._member_map_[self.item_type_combo.currentText()])]
+    def update_profile_alias(self, value: str):
+        self.unique_model.profileAlias = value.strip()
 
     def update_min_power(self):
         self.unique_model.minPower = self.min_power.value()
@@ -225,22 +90,6 @@ class UniqueWidget(QWidget):
 
     def update_min_percent(self):
         self.unique_model.minPercentOfAspect = self.min_percent.value()
-
-    def update_mythic(self):
-        self.unique_model.mythic = self.mythic.isChecked()
-
-    def update_aspect_name(self):
-        self.unique_model.aspect.name = self.aspect_name_combo.currentText()
-
-    def update_aspect_value(self, value):
-        try:
-            self.unique_model.aspect.value = float(value) if value else None
-        except ValueError:
-            return
-
-    def update_aspect_comparison(self):
-        comparison = self.comparison_combo.currentText()
-        self.unique_model.aspect.comparison = ComparisonType(comparison)
 
 
 class UniquesTab(QWidget):
@@ -272,31 +121,22 @@ class UniquesTab(QWidget):
         self.toolbar.setMovable(False)
         for i, unique_model in enumerate(self.unique_model_list):
             group = UniqueWidget(unique_model)
-            self.tab_widget.addTab(group, f"Unique {i}")
-        # Add buttons to toolbar
-        add_item_button = QPushButton("Create Unique")
-        remove_item_button = QPushButton("Remove Unique")
-        add_aspect_button = QPushButton("Add Aspect to current unique")
-        remove_aspect_button = QPushButton("Remove Aspect to current unique")
-        add_affixes_button = QPushButton("Add Affixes to current unique")
-        remove_affixes_button = QPushButton("Remove Affixes to current unique")
+            self.tab_widget.addTab(group, f"Unique Rule {i}")
+
+        add_item_button = QPushButton("Create Rule")
+        remove_item_button = QPushButton("Remove Rule")
         set_all_minGreaterAffix_button = QPushButton("Set all minGreaterAffix")
+        set_all_minPercentOfAspect_button = QPushButton("Set all minPercentOfAspect")
         set_all_minPower_button = QPushButton("Set all minPower")
         add_item_button.clicked.connect(self.add_item_type)
         remove_item_button.clicked.connect(self.remove_item_type)
-        add_aspect_button.clicked.connect(self.add_aspect_to_current_unique)
-        add_affixes_button.clicked.connect(self.add_affixes_to_current_unique)
-        remove_aspect_button.clicked.connect(self.remove_aspect_from_current_unique)
-        remove_affixes_button.clicked.connect(self.remove_affixes_from_current_unique)
         set_all_minGreaterAffix_button.clicked.connect(self.set_all_minGreaterAffix)
+        set_all_minPercentOfAspect_button.clicked.connect(self.set_all_minPercentOfAspect)
         set_all_minPower_button.clicked.connect(self.set_all_minPower)
         self.toolbar.addWidget(add_item_button)
         self.toolbar.addWidget(remove_item_button)
-        self.toolbar.addWidget(add_aspect_button)
-        self.toolbar.addWidget(remove_aspect_button)
-        self.toolbar.addWidget(add_affixes_button)
-        self.toolbar.addWidget(remove_affixes_button)
         self.toolbar.addWidget(set_all_minGreaterAffix_button)
+        self.toolbar.addWidget(set_all_minPercentOfAspect_button)
         self.toolbar.addWidget(set_all_minPower_button)
         self.main_layout.addWidget(self.toolbar)
         self.main_layout.addWidget(self.tab_widget)
@@ -322,51 +162,13 @@ class UniquesTab(QWidget):
 
     def rename_tabs(self):
         for i in range(self.tab_widget.count()):
-            self.tab_widget.setTabText(i, f"Unique {i}")
+            self.tab_widget.setTabText(i, f"Unique Rule {i}")
 
     def add_item_type(self):
         unique_model = GlobalUniqueModel()
         group = UniqueWidget(unique_model)
-        self.tab_widget.addTab(group, f"Unique {self.tab_widget.count()}")
+        self.tab_widget.addTab(group, f"Unique Rule {self.tab_widget.count()}")
         self.unique_model_list.append(unique_model)
-
-    def add_aspect_to_current_unique(self):
-        current_unique: UniqueWidget = self.tab_widget.currentWidget()
-        if current_unique.unique_model.aspect:
-            QMessageBox.warning(
-                self, "Warn", "An aspect already exist for the current unique. Please modify the existing one."
-            )
-        else:
-            current_unique.unique_model.aspect = AspectUniqueFilterModel(
-                name=min(Dataloader().aspect_unique_dict.keys())
-            )
-            current_unique.create_aspect_groupbox()
-
-    def add_affixes_to_current_unique(self):
-        current_unique: UniqueWidget = self.tab_widget.currentWidget()
-        if current_unique.unique_model.affix:
-            QMessageBox.warning(
-                self, "Warn", "An affix already exist for the current unique. Please modify the existing one."
-            )
-        else:
-            current_unique.unique_model.affix = [AffixFilterModel(name=min(Dataloader().affix_dict.keys()))]
-            current_unique.create_affix_groupbox()
-
-    def remove_aspect_from_current_unique(self):
-        current_unique: UniqueWidget = self.tab_widget.currentWidget()
-        if not current_unique.unique_model.aspect:
-            QMessageBox.warning(self, "Warn", "There is no aspect in the current unique. You can add one.")
-        else:
-            current_unique.unique_model.aspect = None
-            current_unique.remove_aspect_groupbox()
-
-    def remove_affixes_from_current_unique(self):
-        current_unique: UniqueWidget = self.tab_widget.currentWidget()
-        if not current_unique.unique_model.affix:
-            QMessageBox.warning(self, "Warn", "There is no affix in the current unique. You can add one.")
-        else:
-            current_unique.unique_model.affix = []
-            current_unique.remove_affix_groupbox()
 
     def set_all_minGreaterAffix(self):
         dialog = MinGreaterDialog(self)
@@ -376,6 +178,15 @@ class UniquesTab(QWidget):
                 tab: UniqueWidget = self.tab_widget.widget(i)
                 tab.min_greater.setValue(minGreaterAffix)
                 tab.update_min_greater_affix()
+
+    def set_all_minPercentOfAspect(self):
+        dialog = MinPercentDialog(self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            minPercentOfAspect = dialog.get_value()
+            for i in range(self.tab_widget.count()):
+                tab: UniqueWidget = self.tab_widget.widget(i)
+                tab.min_percent.setValue(minPercentOfAspect)
+                tab.update_min_percent()
 
     def set_all_minPower(self):
         dialog = MinPowerDialog(self)

--- a/src/scripts/common.py
+++ b/src/scripts/common.py
@@ -6,7 +6,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from item.data.seasonal_attribute import SeasonalAttribute
+from src.item.data.seasonal_attribute import SeasonalAttribute
 
 if TYPE_CHECKING:
     from tkinter import Canvas

--- a/src/scripts/vision_mode_with_highlighting.py
+++ b/src/scripts/vision_mode_with_highlighting.py
@@ -12,8 +12,8 @@ import numpy as np
 
 import src.item.descr.read_descr_tts
 import src.tts
-from config.helper import singleton
 from src.cam import Cam
+from src.config.helper import singleton
 from src.config.loader import IniConfigLoader
 from src.config.ui import ResManager
 from src.item.data.item_type import is_sigil

--- a/src/template_finder.py
+++ b/src/template_finder.py
@@ -13,7 +13,7 @@ from src.config.ui import ResManager
 from src.utils.image_operations import alpha_to_mask, color_filter, crop
 from src.utils.misc import run_until_condition
 from src.utils.roi_operations import get_center
-from utils.window import screenshot
+from src.utils.window import screenshot
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Root cause: the Profile Editor had drifted from the current profile model. GlobalUniqueModel no longer supports the old per-unique fields, ItemFilterModel.uniqueAspect had no Affixes editor UI, and Add Inherent Pool wrote to affixPool.

Code changes:

Reworked the Uniques tab to edit current GlobalUniqueModel fields only: profileAlias, minPower, minGreaterAffixCount, minPercentOfAspect.
Added uniqueAspect controls to each Affixes item editor.
Fixed Add Inherent Pool so it appends to inherentPool.

Impact: Profile Editor save/load now matches the current profile model more closely, and inherent pools should persist under the correct YAML section.