### PR TITLE
(S13) Removed ComparisonType from all filters. If we need to know if an affix/aspect value should be bigger or smaller we determine it ourselves 

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,11 @@ The instructions below are all about editing the file manually, but the explanat
 
 # Filter for attack speed
 - { name: attack_speed }
-# Filter for attack speed larger than 4
+# Filter for attack speed with a threshold value.
+# The filter keeps larger rolls when the tooltip range increases and smaller rolls when the range decreases.
 - { name: attack_speed, value: 4 }
 # Filter for attack speed where the affix is greater than 50% of the potential maximum
 - { name: attack_speed, minPercentOfAffix: 50 }
-# Filter for attack speed smaller than 4
-- { name: attack_speed, value: 4, comparison: smaller }
 ```
 
 </details>
@@ -329,7 +328,7 @@ in [assets/lang/enUS/affixes.json](assets/lang/enUS/affixes.json).
 
 You also have the option to filter on the minimum percent of the affix you want instead of a specific value. For example, say you want strength on an item. The potential values for strength are 100-150. If you say the `minPercentOfAffix` for strength is 50 (which means 50%), then strength rolls of 125 and up are kept and rolls below 125 would be discarded.
 
-A greater affix is considered to always match a `minPercentOfAffix`. You do not need to designate larger/smaller for `minPercentOfAffix`, that is automatically determined.
+A greater affix is considered to always match a `minPercentOfAffix`. You do not need to designate larger/smaller for `value` or `minPercentOfAffix`; that is automatically determined from the roll range.
 
 If you put in `minPercentOfAffix` you can not also put `value` for that affix. It must be one or the other.
 

--- a/src/config/profile_models.py
+++ b/src/config/profile_models.py
@@ -13,11 +13,6 @@ from src.item.data.rarity import ItemRarity
 MODULE_LOGGER = logging.getLogger(__name__)
 
 
-class ComparisonType(enum.StrEnum):
-    larger = enum.auto()
-    smaller = enum.auto()
-
-
 def _parse_item_type_or_rarities(data: str | list[str]) -> list[str]:
     if isinstance(data, str):
         return [data]
@@ -28,7 +23,6 @@ class AffixAspectFilterModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str
     value: float | None = None
-    comparison: ComparisonType = ComparisonType.larger
 
     @model_validator(mode="before")
     @classmethod
@@ -38,16 +32,14 @@ class AffixAspectFilterModel(BaseModel):
         if isinstance(data, str):
             return {"name": data}
         if isinstance(data, list):
-            if not data or len(data) > 3:
-                msg = "list, cannot be empty or larger than 3 items"
+            if not data or len(data) > 2:
+                msg = "list, cannot be empty or larger than 2 items"
                 raise ValueError(msg)
             result = {}
             if len(data) >= 1:
                 result["name"] = data[0]
             if len(data) >= 2:
                 result["value"] = data[1]
-            if len(data) == 3:
-                result["comparison"] = data[2]
             return result
         msg = "must be str or list"
         raise ValueError(msg)

--- a/src/gui/profile_editor/affixes_tab.py
+++ b/src/gui/profile_editor/affixes_tab.py
@@ -30,7 +30,6 @@ from src.config.profile_models import (
     AffixFilterCountModel,
     AffixFilterModel,
     AspectUniqueFilterModel,
-    ComparisonType,
     DynamicItemFilterModel,
 )
 from src.dataloader import Dataloader
@@ -214,17 +213,6 @@ class AffixGroupEditor(QWidget):
         self.unique_aspect_value_edit.textChanged.connect(self.update_unique_aspect_value)
         self.unique_aspect_form.addRow("Threshold:", self.unique_aspect_value_edit)
 
-        self.unique_aspect_comparison_combo = IgnoreScrollWheelComboBox()
-        self.unique_aspect_comparison_combo.setEditable(True)
-        self.unique_aspect_comparison_combo.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
-        self.unique_aspect_comparison_combo.completer().setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
-        self.unique_aspect_comparison_combo.setFixedSize(100, self.unique_aspect_comparison_combo.sizeHint().height())
-        self.unique_aspect_comparison_combo.addItems([ct.value for ct in ComparisonType])
-        if self.config.uniqueAspect is not None:
-            self.unique_aspect_comparison_combo.setCurrentText(self.config.uniqueAspect.comparison.value)
-        self.unique_aspect_comparison_combo.currentTextChanged.connect(self.update_unique_aspect_comparison)
-        self.unique_aspect_form.addRow("Comparison:", self.unique_aspect_comparison_combo)
-
         self.unique_aspect_groupbox.setLayout(self.unique_aspect_form)
         self.content_layout.addWidget(self.unique_aspect_groupbox)
         self.refresh_unique_aspect_value_input()
@@ -239,9 +227,6 @@ class AffixGroupEditor(QWidget):
         self.unique_aspect_name_combo.setEnabled(True)
         self.unique_aspect_mode_combo.setEnabled(enabled)
         self.unique_aspect_value_edit.setEnabled(enabled)
-        self.unique_aspect_comparison_combo.setEnabled(
-            enabled and self.unique_aspect_mode_combo.currentText() == AFFIX_VALUE_MODE
-        )
 
     def update_unique_aspect_name(self, current_text=None):
         aspect_name = self.unique_aspect_name_combo.currentText() if current_text is None else current_text
@@ -316,14 +301,6 @@ class AffixGroupEditor(QWidget):
             return
         self.config.uniqueAspect.minPercentOfAspect = 0
 
-    def update_unique_aspect_comparison(self, current_text=None):
-        if self.config.uniqueAspect is None:
-            return
-        comparison = current_text or self.unique_aspect_comparison_combo.currentText()
-        if comparison not in {comparison_type.value for comparison_type in ComparisonType}:
-            return
-        self.config.uniqueAspect.comparison = ComparisonType(comparison)
-
     def init_affix_pool(self):
         """Initialize affix pool content on first expansion."""
         for pool in self.config.affixPool:
@@ -358,7 +335,6 @@ class AffixGroupEditor(QWidget):
         default_affix = AffixFilterModel(
             name=next(iter(Dataloader().affix_dict.keys())),  # First valid affix name
             value=None,
-            comparison=ComparisonType.larger,
         )
 
         new_pool = AffixFilterCountModel(count=[default_affix], minCount=1, maxCount=3)
@@ -369,7 +345,6 @@ class AffixGroupEditor(QWidget):
         default_affix = AffixFilterModel(
             name=next(iter(Dataloader().affix_dict.keys())),  # First valid affix name
             value=None,
-            comparison=ComparisonType.larger,
         )
 
         new_pool = AffixFilterCountModel(count=[default_affix], minCount=1, maxCount=3)
@@ -559,10 +534,6 @@ class AffixPoolWidget(QWidget):
         value_label.setProperty("affixHeaderLabel", True)
         self._refresh_widget_style(value_label)
 
-        comparison_label = QLabel("Comparison")
-        comparison_label.setProperty("affixHeaderLabel", True)
-        self._refresh_widget_style(comparison_label)
-
         title_layout.addSpacing(250)
         title_layout.addWidget(affix_label)
         title_layout.addSpacing(400)
@@ -571,8 +542,6 @@ class AffixPoolWidget(QWidget):
         title_layout.addWidget(mode_label)
         title_layout.addSpacing(85)
         title_layout.addWidget(value_label)
-        title_layout.addSpacing(85)
-        title_layout.addWidget(comparison_label)
 
         self.affix_list = QListWidget()
         self.affix_list.setMinimumHeight(200)
@@ -607,9 +576,7 @@ class AffixPoolWidget(QWidget):
         self.affix_list.setItemWidget(item, widget)
 
     def add_affix(self):
-        new_affix = AffixFilterModel(
-            name=next(iter(Dataloader().affix_dict.keys())), value=None, comparison=ComparisonType.larger
-        )
+        new_affix = AffixFilterModel(name=next(iter(Dataloader().affix_dict.keys())), value=None)
         self.pool.count.append(new_affix)
         self.add_affix_item(new_affix)
 
@@ -641,7 +608,6 @@ class AffixWidget(QWidget):
         self.create_greater_checkbox()
         self.create_mode_combobox()
         self.create_value_input()
-        self.create_comparison_combobox()
         self.mode_combo.currentTextChanged.connect(self.update_mode)
         self.update_mode(self.mode_combo.currentText())
 
@@ -649,7 +615,6 @@ class AffixWidget(QWidget):
         layout.addWidget(self.greater_checkbox)
         layout.addWidget(self.mode_combo)
         layout.addWidget(self.value_edit)
-        layout.addWidget(self.comparison_combo)
 
         self.setLayout(layout)
 
@@ -702,17 +667,6 @@ class AffixWidget(QWidget):
         self.value_edit.setFixedSize(100, self.value_edit.sizeHint().height())
         self.value_edit.textChanged.connect(self.update_value)
 
-    def create_comparison_combobox(self):
-        self.comparison_combo = IgnoreScrollWheelComboBox()
-        self.comparison_combo.setEditable(True)
-        self.comparison_combo.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
-        self.comparison_combo.completer().setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
-        self.comparison_combo.setFixedSize(100, self.comparison_combo.sizeHint().height())
-        self.comparison_combo.addItems([ct.value for ct in ComparisonType])
-        self.comparison_combo.setCurrentText(self.affix.comparison.value)
-        self.comparison_combo.currentTextChanged.connect(self.update_comparison)
-        self.affix.comparison = ComparisonType(self.affix.comparison.value)
-
     def update_name(self, current_text=None):
         """Update the model only when the editable combobox contains a valid affix."""
         reverse_dict = {v: k for k, v in Dataloader().affix_dict.items()}
@@ -726,12 +680,10 @@ class AffixWidget(QWidget):
             self.value_edit.setPlaceholderText("Percent (0-100)")
             self.value_edit.setValidator(QIntValidator(0, 100, self.value_edit))
             display_value = "" if self.affix.minPercentOfAffix == 0 else str(self.affix.minPercentOfAffix)
-            self.comparison_combo.setEnabled(False)
         else:
             self.value_edit.setPlaceholderText("Value (optional)")
             self.value_edit.setValidator(QDoubleValidator(self.value_edit))
             display_value = "" if self.affix.value is None else str(self.affix.value)
-            self.comparison_combo.setEnabled(True)
 
         self.value_edit.blockSignals(True)
         self.value_edit.setText(display_value)
@@ -764,12 +716,6 @@ class AffixWidget(QWidget):
         except ValueError:
             return
         self.affix.minPercentOfAffix = 0
-
-    def update_comparison(self, current_text=None):
-        comparison = current_text or self.comparison_combo.currentText()
-        if comparison not in {comparison_type.value for comparison_type in ComparisonType}:
-            return
-        self.affix.comparison = ComparisonType(comparison)
 
     def update_greater(self):
         self.affix.want_greater = self.greater_checkbox.isChecked()

--- a/src/item/filter.py
+++ b/src/item/filter.py
@@ -429,11 +429,13 @@ class Filter:
     def _match_item_aspect_or_affix(
         self,
         expected_aspect: AffixAspectFilterModel | None,
-        item_aspect: Aspect | Affix,
+        item_aspect: Aspect | Affix | None,
         is_fixed_aspect_value: bool = False,
     ) -> bool:
         if expected_aspect is None:
             return True
+        if item_aspect is None:
+            return False
         if expected_aspect.name != item_aspect.name:
             return False
 

--- a/src/item/filter.py
+++ b/src/item/filter.py
@@ -15,7 +15,6 @@ from src.config.profile_models import (
     AffixAspectFilterModel,
     AffixFilterCountModel,
     AffixFilterModel,
-    ComparisonType,
     DynamicItemFilterModel,
     GlobalUniqueModel,
     ProfileModel,
@@ -398,7 +397,10 @@ class Filter:
         if expected_percent == 0 or item_aspect_or_affix.max_value is None or item_aspect_or_affix.min_value is None:
             return True
 
-        if item_aspect_or_affix.max_value > item_aspect_or_affix.min_value:
+        if item_aspect_or_affix.max_value == item_aspect_or_affix.min_value:
+            return True
+
+        if not Filter._is_smaller_roll_better(item_aspect_or_affix):
             percent_float = expected_percent / 100.0
             return (item_aspect_or_affix.value - item_aspect_or_affix.min_value) / (
                 item_aspect_or_affix.max_value - item_aspect_or_affix.min_value
@@ -409,6 +411,20 @@ class Filter:
         return (item_aspect_or_affix.value - item_aspect_or_affix.max_value) / (
             item_aspect_or_affix.min_value - item_aspect_or_affix.max_value
         ) <= percent_float
+
+    @staticmethod
+    def _is_smaller_roll_better(item_aspect_or_affix: Aspect | Affix) -> bool:
+        return (
+            item_aspect_or_affix.max_value is not None
+            and item_aspect_or_affix.min_value is not None
+            and item_aspect_or_affix.max_value < item_aspect_or_affix.min_value
+        )
+
+    @staticmethod
+    def _match_item_value_threshold(expected_value: float, item_aspect_or_affix: Aspect | Affix) -> bool:
+        if Filter._is_smaller_roll_better(item_aspect_or_affix):
+            return item_aspect_or_affix.value <= expected_value
+        return item_aspect_or_affix.value >= expected_value
 
     def _match_item_aspect_or_affix(
         self,
@@ -426,9 +442,7 @@ class Filter:
                 # Chaos uniques and probably bloodied items have a fixed aspect number.
                 # There is no reason to compare it, it is always at max
                 return bool(is_fixed_aspect_value)
-            if (expected_aspect.comparison == ComparisonType.larger and item_aspect.value < expected_aspect.value) or (
-                expected_aspect.comparison == ComparisonType.smaller and item_aspect.value > expected_aspect.value
-            ):
+            if not self._match_item_value_threshold(expected_aspect.value, item_aspect):
                 return False
         expected_affix_percent = getattr(expected_aspect, "minPercentOfAffix", 0)
         if expected_affix_percent:

--- a/tests/item/filter/data/affixes.py
+++ b/tests/item/filter/data/affixes.py
@@ -43,10 +43,10 @@ affixes = [
         TestItem(
             item_type=ItemType.Boots,
             affixes=[
-                Affix(name="cold_resistance", value=5),
+                Affix(name="cold_resistance", value=5, min_value=5, max_value=4),
                 Affix(name="movement_speed", value=5),
-                Affix(name="fire_resistance", value=5),
-                Affix(name="shadow_resistance", value=5),
+                Affix(name="fire_resistance", value=5, min_value=5, max_value=4),
+                Affix(name="shadow_resistance", value=5, min_value=5, max_value=4),
             ],
         ),
     ),
@@ -64,9 +64,9 @@ affixes = [
         TestItem(
             item_type=ItemType.Boots,
             affixes=[
-                Affix(name="cold_resistance", value=5),
+                Affix(name="cold_resistance", value=5, min_value=5, max_value=4),
                 Affix(name="movement_speed", value=5),
-                Affix(name="shadow_resistance", value=5),
+                Affix(name="shadow_resistance", value=5, min_value=5, max_value=4),
             ],
         ),
     ),
@@ -90,8 +90,8 @@ affixes = [
             item_type=ItemType.Boots,
             affixes=[
                 Affix(name="movement_speed", value=5),
-                Affix(name="cold_resistance", value=5),
-                Affix(name="lightning_resistance", value=5),
+                Affix(name="cold_resistance", value=5, min_value=5, max_value=4),
+                Affix(name="lightning_resistance", value=5, min_value=5, max_value=4),
             ],
             inherent=[Affix(name="maximum_evade_charges", value=5)],
         ),
@@ -103,8 +103,8 @@ affixes = [
             item_type=ItemType.Boots,
             affixes=[
                 Affix(name="movement_speed", value=5),
-                Affix(name="cold_resistance", value=5),
-                Affix(name="lightning_resistance", value=5),
+                Affix(name="cold_resistance", value=5, min_value=5, max_value=4),
+                Affix(name="lightning_resistance", value=5, min_value=5, max_value=4),
             ],
             inherent=[Affix(name="maximum_fury", value=5)],
         ),
@@ -116,8 +116,8 @@ affixes = [
             item_type=ItemType.Boots,
             affixes=[
                 Affix(name="movement_speed", value=4),
-                Affix(name="cold_resistance", value=4),
-                Affix(name="lightning_resistance", value=4),
+                Affix(name="cold_resistance", value=4, min_value=5, max_value=4),
+                Affix(name="lightning_resistance", value=4, min_value=5, max_value=4),
             ],
             inherent=[Affix(name="maximum_fury", value=5)],
         ),

--- a/tests/item/filter/data/affixes.py
+++ b/tests/item/filter/data/affixes.py
@@ -5,7 +5,7 @@ from src.item.models import Item
 
 
 class TestItem(Item):
-    def __init__(self, rarity=ItemRarity.Legendary, power=910, **kwargs):
+    def __init__(self, rarity: ItemRarity = ItemRarity.Legendary, power=910, **kwargs):
         super().__init__(rarity=rarity, power=power, **kwargs)
 
 

--- a/tests/item/filter/data/filters.py
+++ b/tests/item/filter/data/filters.py
@@ -1,7 +1,6 @@
 from src.config.profile_models import (
     AffixFilterCountModel,
     AffixFilterModel,
-    ComparisonType,
     GlobalUniqueModel,
     ItemFilterModel,
     ProfileModel,
@@ -59,11 +58,11 @@ affix = ProfileModel(
                     AffixFilterCountModel(count=[AffixFilterModel(name="movement_speed")]),
                     AffixFilterCountModel(
                         count=[
-                            AffixFilterModel(name="shadow_resistance", value=4, comparison=ComparisonType.smaller),
-                            AffixFilterModel(name="cold_resistance", value=4, comparison=ComparisonType.smaller),
-                            AffixFilterModel(name="lightning_resistance", value=4, comparison=ComparisonType.smaller),
-                            AffixFilterModel(name="poison_resistance", value=4, comparison=ComparisonType.smaller),
-                            AffixFilterModel(name="fire_resistance", value=4, comparison=ComparisonType.smaller),
+                            AffixFilterModel(name="shadow_resistance", value=4),
+                            AffixFilterModel(name="cold_resistance", value=4),
+                            AffixFilterModel(name="lightning_resistance", value=4),
+                            AffixFilterModel(name="poison_resistance", value=4),
+                            AffixFilterModel(name="fire_resistance", value=4),
                         ],
                         minCount=2,
                     ),
@@ -313,6 +312,11 @@ unique_affixes = ProfileModel(
             )
         },
         {"UniqueAspectOnly": ItemFilterModel(uniqueAspect={"name": "battle_trance"})},
+        {
+            "SmallerUniqueAspectValue": ItemFilterModel(
+                itemType=[ItemType.Shield], uniqueAspect={"name": "crown_of_lucion", "value": 12}
+            )
+        },
         {"UniqueAspectWithGA": ItemFilterModel(uniqueAspect={"name": "flickerstep"}, minGreaterAffixCount=2)},
     ],
 )

--- a/tests/item/filter/data/uniques.py
+++ b/tests/item/filter/data/uniques.py
@@ -55,7 +55,11 @@ global_uniques = [
 
 uniques_with_affixes = [
     ("matches nothing", [], TestUnique(item_type=ItemType.Amulet, aspect=Aspect(name="dolmen_stone"))),
-    ("unique aspect missing", [], TestUnique(item_type=ItemType.Helm, affixes=[Affix(name="maximum_life", value=641)])),
+    (
+        "rare does not match unique aspect filter",
+        [],
+        TestUnique(rarity=ItemRarity.Rare, item_type=ItemType.Helm, affixes=[Affix(name="maximum_life", value=641)]),
+    ),
     (
         "matches aspect value",
         ["test.Helm"],

--- a/tests/item/filter/data/uniques.py
+++ b/tests/item/filter/data/uniques.py
@@ -126,4 +126,9 @@ uniques_with_affixes = [
         ),
     ),
     ("aspect only", ["test.UniqueAspectOnly"], TestUnique(aspect=Aspect(name="battle_trance"))),
+    (
+        "smaller aspect value",
+        ["test.SmallerUniqueAspectValue"],
+        TestUnique(aspect=Aspect(name="crown_of_lucion", value=10, min_value=15, max_value=10)),
+    ),
 ]

--- a/tests/item/filter/data/uniques.py
+++ b/tests/item/filter/data/uniques.py
@@ -55,6 +55,7 @@ global_uniques = [
 
 uniques_with_affixes = [
     ("matches nothing", [], TestUnique(item_type=ItemType.Amulet, aspect=Aspect(name="dolmen_stone"))),
+    ("unique aspect missing", [], TestUnique(item_type=ItemType.Helm, affixes=[Affix(name="maximum_life", value=641)])),
     (
         "matches aspect value",
         ["test.Helm"],

--- a/tests/item/filter/data/uniques.py
+++ b/tests/item/filter/data/uniques.py
@@ -6,7 +6,9 @@ from src.item.models import Item
 
 
 class TestUnique(Item):
-    def __init__(self, rarity=ItemRarity.Unique, item_type: ItemType = ItemType.Shield, power=910, **kwargs):
+    def __init__(
+        self, rarity: ItemRarity = ItemRarity.Unique, item_type: ItemType = ItemType.Shield, power=910, **kwargs
+    ):
         super().__init__(rarity=rarity, item_type=item_type, power=power, **kwargs)
 
 


### PR DESCRIPTION
ComparisonType duplicated roll-direction data already available from item min_value/max_value, but direct value matching still depended on the persisted/profile-editor comparison field.

Changed files:


src/config/profile_models.py: removed ComparisonType and comparison; list shorthand now accepts only name/value.

src/item/filter.py: direct value thresholds now infer smaller/larger from roll range, matching percent logic.

src/gui/profile_editor/affixes_tab.py: removed comparison controls and model writes.

tests/item/filter/data/affixes.py, filters.py, uniques.py: updated fixtures and added smaller-is-better aspect coverage.

README.md: removed comparison docs and documented automatic direction.