### PR TITLE
(BugFix) Attempted fix for issue that would have us read in the loot filter as TTS information

### DIFF
--- a/src/item/descr/read_descr_tts.py
+++ b/src/item/descr/read_descr_tts.py
@@ -277,7 +277,10 @@ def _create_base_item_from_tts(tts_item: list[str]) -> Item | None:
         item.name = Dataloader().bad_tts_uniques[item.name]
     for line in tts_item:
         if "item power" in line.lower():
-            item.power = int(find_number(line))
+            item_power = find_number(line)
+            if item_power is None:
+                return None
+            item.power = int(item_power)
             break
     return item
 

--- a/src/tts.py
+++ b/src/tts.py
@@ -124,7 +124,7 @@ def read_pipe() -> None:
 
 
 def find_item_start(data: list[str]) -> int | None:
-    ignored_words = ["COMPASS AFFIXES", "DUNGEON AFFIXES", "AFFIXES"]
+    ignored_words = ["COMPASS AFFIXES", "DUNGEON AFFIXES", "AFFIXES", "SELECT ALL"]
 
     for index, item in reversed(list(enumerate(data))):
         if any(ignored in item for ignored in ignored_words):

--- a/tests/item/read_descr_tts_test.py
+++ b/tests/item/read_descr_tts_test.py
@@ -1,0 +1,19 @@
+import src.tts
+from src.item.descr.read_descr_tts import read_descr
+
+LOOT_FILTER_TTS = [
+    "SELECT ALL",
+    "Checkbox Disabled",
+    "Item Power Range",
+    "Left mouse button",
+]
+
+
+def test_loot_filter_controls_are_not_tts_item_start():
+    assert src.tts.find_item_start(LOOT_FILTER_TTS) is None
+
+
+def test_loot_filter_controls_do_not_raise_tts_parser_error():
+    src.tts.LAST_ITEM = LOOT_FILTER_TTS
+
+    assert read_descr() is None


### PR DESCRIPTION
The TTS item detector treated the loot-filter UI text SELECT ALL as an item start because it is all uppercase. That caused the loot-filter dialog text to be parsed as an item. Then read_descr_tts saw Item Power Range, tried to extract a number, got None, and crashed with int(None).

Changed files:

src/tts.py: ignores SELECT ALL as a TTS item start.
src/item/descr/read_descr_tts.py: safely returns None when an Item Power line has no number.
tests/item/read_descr_tts_test.py: adds regression tests for this loot-filter TTS case.