### PR TITLE
(Development) Profiles are sorted alphabetically and AspectUpgrades are shown in block format

### DIFF
--- a/src/gui/importer/d4builds.py
+++ b/src/gui/importer/d4builds.py
@@ -26,6 +26,7 @@ from src.gui.importer.gui_common import (
     match_to_enum,
     retry_importer,
     save_as_profile,
+    sort_profile_filters,
     update_mingreateraffixcount,
 )
 from src.gui.importer.importer_config import ImportConfig
@@ -192,7 +193,7 @@ def import_d4builds(config: ImportConfig, driver: ChromiumDriver = None):
             filter_name = f"{filter_name_template}{i}"
             i += 1
         finished_filters.append({filter_name: item_filter})
-    profile = ProfileModel(name="imported profile", Affixes=sorted(finished_filters, key=lambda x: next(iter(x))))
+    profile = ProfileModel(name="imported profile", Affixes=sort_profile_filters(finished_filters))
     if config.import_aspect_upgrades and aspect_upgrade_filters:
         profile.AspectUpgrades = aspect_upgrade_filters
 

--- a/src/gui/importer/gui_common.py
+++ b/src/gui/importer/gui_common.py
@@ -175,6 +175,17 @@ def update_mingreateraffixcount(item_filter: ItemFilterModel, require_gas: bool)
         item_filter.minGreaterAffixCount = 0
 
 
+def sort_profile_filters(filters: list[dict[str, ItemFilterModel]]) -> list[dict[str, ItemFilterModel]]:
+    return sorted(filters, key=_profile_filter_sort_key)
+
+
+def _profile_filter_sort_key(filter_entry: dict[str, ItemFilterModel]) -> str:
+    filter_name, item_filter = next(iter(filter_entry.items()))
+    if item_filter.uniqueAspect is not None:
+        return item_filter.uniqueAspect.name.casefold()
+    return filter_name.casefold()
+
+
 def get_with_retry(url: str, custom_headers: dict[str, str] | None = None) -> httpx.Response:
     for _ in range(10):
         try:
@@ -272,11 +283,23 @@ def _to_yaml_str(profile: ProfileModel, exclude_defaults: bool, exclude: set[str
     yaml = YAML()
     yaml.default_flow_style = None  # Back to original
     dict_val = yaml.load(str_val)
+    _sort_profile_sections(dict_val)
     _rm_style_info(dict_val)
+    _use_block_style(dict_val.get("AspectUpgrades"))
     stream = StringIO()
     yaml.dump(dict_val, stream)
     stream.seek(0)
     return stream.read()
+
+
+def _sort_profile_sections(d):
+    if isinstance(d, dict) and isinstance(d.get("AspectUpgrades"), list):
+        d["AspectUpgrades"].sort(key=str.casefold)
+
+
+def _use_block_style(d):
+    if hasattr(d, "fa"):
+        d.fa.set_block_style()
 
 
 def _rm_style_info(d):

--- a/src/gui/importer/gui_common.py
+++ b/src/gui/importer/gui_common.py
@@ -180,9 +180,7 @@ def sort_profile_filters(filters: list[dict[str, ItemFilterModel]]) -> list[dict
 
 
 def _profile_filter_sort_key(filter_entry: dict[str, ItemFilterModel]) -> str:
-    filter_name, item_filter = next(iter(filter_entry.items()))
-    if item_filter.uniqueAspect is not None:
-        return item_filter.uniqueAspect.name.casefold()
+    filter_name, _ = next(iter(filter_entry.items()))
     return filter_name.casefold()
 
 

--- a/src/gui/importer/maxroll.py
+++ b/src/gui/importer/maxroll.py
@@ -22,6 +22,7 @@ from src.gui.importer.gui_common import (
     match_to_enum,
     retry_importer,
     save_as_profile,
+    sort_profile_filters,
     update_mingreateraffixcount,
 )
 from src.gui.importer.importer_config import ImportConfig
@@ -157,7 +158,7 @@ def import_maxroll(config: ImportConfig):
             i += 1
 
         finished_filters.append({filter_name: item_filter})
-    profile = ProfileModel(name="imported profile", Affixes=sorted(finished_filters, key=lambda x: next(iter(x))))
+    profile = ProfileModel(name="imported profile", Affixes=sort_profile_filters(finished_filters))
     if config.import_aspect_upgrades and aspect_upgrade_filters:
         profile.AspectUpgrades = aspect_upgrade_filters
 

--- a/src/gui/importer/maxroll.py
+++ b/src/gui/importer/maxroll.py
@@ -279,6 +279,8 @@ def _find_item_affixes(
                             attr_desc = "to aura skills"
                         elif param_id == 850110203 and attribute_id == 1155:
                             attr_desc = "to demonology skills"
+                        elif param_id == -2005545408 and attribute_id == 1155:
+                            attr_desc = "to ancient skills"
             clean_desc = re.sub(r"\[.*?\]|[^a-zA-Z ]", "", attr_desc)
             clean_desc = clean_desc.replace("SecondSeconds", "seconds")
             if not clean_desc:

--- a/src/gui/importer/mobalytics.py
+++ b/src/gui/importer/mobalytics.py
@@ -24,6 +24,7 @@ from src.gui.importer.gui_common import (
     match_to_enum,
     retry_importer,
     save_as_profile,
+    sort_profile_filters,
     update_mingreateraffixcount,
 )
 from src.gui.importer.importer_config import ImportConfig
@@ -202,7 +203,7 @@ def import_mobalytics(config: ImportConfig):
             filter_name = f"{filter_name_template}{i}"
             i += 1
         finished_filters.append({filter_name: item_filter})
-    profile = ProfileModel(name="imported profile", Affixes=sorted(finished_filters, key=lambda x: next(iter(x))))
+    profile = ProfileModel(name="imported profile", Affixes=sort_profile_filters(finished_filters))
     if config.import_aspect_upgrades and aspect_upgrade_filters:
         profile.AspectUpgrades = aspect_upgrade_filters
 

--- a/tests/gui/importer/test_gui_common.py
+++ b/tests/gui/importer/test_gui_common.py
@@ -1,4 +1,5 @@
-from src.gui.importer.gui_common import build_default_profile_file_name
+from src.config.profile_models import AspectUniqueFilterModel, ItemFilterModel, ProfileModel
+from src.gui.importer.gui_common import _to_yaml_str, build_default_profile_file_name, sort_profile_filters
 
 
 def test_build_default_profile_file_name_maxroll() -> None:
@@ -51,3 +52,23 @@ def test_build_default_profile_file_name_replaces_stale_season_marker_in_header(
     )
 
     assert file_name == "maxroll_sorcerer_s12_crackling_energy_sorc"
+
+
+def test_to_yaml_str_sorts_aspect_upgrades_and_uses_block_style(mock_ini_loader) -> None:
+    profile = ProfileModel(name="test", AspectUpgrades=["snowveiled", "accelerating"])
+
+    yaml_str = _to_yaml_str(profile, exclude_defaults=True, exclude={"name", "Sigils"})
+
+    assert "AspectUpgrades:\n- accelerating\n- snowveiled\n" in yaml_str
+    assert "AspectUpgrades: [" not in yaml_str
+
+
+def test_sort_profile_filters_uses_unique_aspect_name(mock_ini_loader) -> None:
+    filters = [
+        {"Amulet": ItemFilterModel(uniqueAspect=AspectUniqueFilterModel(name="flickerstep"))},
+        {"Ring": ItemFilterModel(uniqueAspect=AspectUniqueFilterModel(name="battle_trance"))},
+    ]
+
+    sorted_filters = sort_profile_filters(filters)
+
+    assert [next(iter(profile_filter)) for profile_filter in sorted_filters] == ["Ring", "Amulet"]

--- a/tests/gui/importer/test_gui_common.py
+++ b/tests/gui/importer/test_gui_common.py
@@ -1,5 +1,5 @@
-from src.config.profile_models import AspectUniqueFilterModel, ItemFilterModel, ProfileModel
-from src.gui.importer.gui_common import _to_yaml_str, build_default_profile_file_name, sort_profile_filters
+from src.config.profile_models import ProfileModel
+from src.gui.importer.gui_common import _to_yaml_str, build_default_profile_file_name
 
 
 def test_build_default_profile_file_name_maxroll() -> None:
@@ -61,14 +61,3 @@ def test_to_yaml_str_sorts_aspect_upgrades_and_uses_block_style(mock_ini_loader)
 
     assert "AspectUpgrades:\n- accelerating\n- snowveiled\n" in yaml_str
     assert "AspectUpgrades: [" not in yaml_str
-
-
-def test_sort_profile_filters_uses_unique_aspect_name(mock_ini_loader) -> None:
-    filters = [
-        {"Amulet": ItemFilterModel(uniqueAspect=AspectUniqueFilterModel(name="flickerstep"))},
-        {"Ring": ItemFilterModel(uniqueAspect=AspectUniqueFilterModel(name="battle_trance"))},
-    ]
-
-    sorted_filters = sort_profile_filters(filters)
-
-    assert [next(iter(profile_filter)) for profile_filter in sorted_filters] == ["Ring", "Amulet"]


### PR DESCRIPTION
AspectUpgrades kept source order and YAML dumped scalar lists inline. Imported unique filters were sorted by slot/filter name, not by the unique aspect name.