### PR TITLE
(BugFix) Resolved issue where Evade Grants +whatever% Movement Speed for 1.5 Seconds was incorrectly getting read as a greater affix

### DIFF
--- a/src/item/descr/read_descr_tts.py
+++ b/src/item/descr/read_descr_tts.py
@@ -49,7 +49,7 @@ _ASPECT_RE = re.compile(
     r" - (?P<maxvalue>[0-9]+[.]?[0-9]*)]"
 )
 
-_FOR_SECONDS_RE = re.compile(r"for (?P<forsecondsvalue>\d) Seconds")
+_FOR_SECONDS_RE = re.compile(r"for (?P<forsecondsvalue>\d+(?:\.\d+)?) Seconds")
 
 _REPLACE_COMPARE_RE = re.compile(r"\(.*\)")
 

--- a/tests/item/read_descr_season_13_tts_test.py
+++ b/tests/item/read_descr_season_13_tts_test.py
@@ -75,7 +75,7 @@ items = [
             seasonal_attribute=None,
         ),
     ),
-    # Boots also lost their inherents
+    # Boots also lost their inherents and Evade grants whatever for 1.5 seconds was being read as a GA
     (
         [
             "MARCH INCEPTION",
@@ -118,12 +118,12 @@ items = [
                     value=439.0,
                 ),
                 Affix(
-                    max_value=None,
-                    min_value=None,
+                    max_value=125.0,
+                    min_value=100.0,
                     name="evade_grants_movement_speed_for_seconds",
                     text="Evade Grants +114% Movement Speed for 1.5 Seconds [100 - 125]%[1.5]",
-                    type=AffixType.greater,
-                    value=1.5,
+                    type=AffixType.normal,
+                    value=114.0,
                 ),
             ],
             aspect=None,


### PR DESCRIPTION
…