### PR TITLE
(New Feature) You can now disable a hotkey if you want it completely turned off.

### DIFF
--- a/src/config/helper.py
+++ b/src/config/helper.py
@@ -5,6 +5,20 @@ if sys.platform != "darwin":
     import keyboard
 
 
+def _drop_negative_scan_codes(scan_codes: tuple[int, ...]) -> tuple[int, ...]:
+    positive_scan_codes = tuple(scan_code for scan_code in scan_codes if scan_code > 0)
+    return positive_scan_codes or scan_codes
+
+
+def to_keyboard_hotkey(hotkey: str) -> tuple[tuple[tuple[int, ...], ...], ...] | str:
+    if not hotkey:
+        return hotkey
+
+    return tuple(
+        tuple(_drop_negative_scan_codes(scan_codes) for scan_codes in step) for step in keyboard.parse_hotkey(hotkey)
+    )
+
+
 def check_greater_than_zero(v: int) -> int:
     if v < 0:
         msg = "must be greater than zero"
@@ -20,8 +34,13 @@ def validate_percent(v: int) -> int:
     return v
 
 
-def validate_hotkey(k: str) -> str:
-    keyboard.parse_hotkey(k)
+def validate_hotkey(k: str, *, allow_empty: bool = False) -> str:
+    if not k:
+        if allow_empty:
+            return k
+        keyboard.parse_hotkey(k)
+        return k
+    keyboard.parse_hotkey(to_keyboard_hotkey(k))
     return k
 
 

--- a/src/config/settings_models.py
+++ b/src/config/settings_models.py
@@ -155,6 +155,7 @@ class AdvancedOptionsModel(_IniBaseModel):
             self.run_filter_force_refresh,
             self.run_vision_mode,
         ]
+        keys = [key for key in keys if key]
         if len(set(keys)) != len(keys):
             msg = "hotkeys must be unique"
             raise ValueError(msg)
@@ -173,7 +174,7 @@ class AdvancedOptionsModel(_IniBaseModel):
     )
     @classmethod
     def key_must_exist(cls, k: str) -> str:
-        return validate_hotkey(k)
+        return validate_hotkey(k, allow_empty=True)
 
     @field_validator("fast_vision_mode_coordinates", mode="before")
     @classmethod

--- a/src/gui/config_tab.py
+++ b/src/gui/config_tab.py
@@ -6,7 +6,7 @@ import typing
 from pathlib import Path
 
 from pydantic import BaseModel, ValidationError
-from PyQt6.QtCore import QCoreApplication, Qt, QTimer
+from PyQt6.QtCore import QCoreApplication, QEvent, Qt, QTimer
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
@@ -35,6 +35,26 @@ from src.config.settings_models import HIDE_FROM_GUI_KEY, IS_HOTKEY_KEY, MoveIte
 from src.gui.open_user_config_button import OpenUserConfigButton
 
 CONFIG_TABNAME = "config"
+DISABLED_HOTKEY_TEXT = "Disabled"
+SPECIAL_HOTKEY_NAMES = {
+    Qt.Key.Key_Left: "left",
+    Qt.Key.Key_Right: "right",
+    Qt.Key.Key_Up: "up",
+    Qt.Key.Key_Down: "down",
+    Qt.Key.Key_Home: "home",
+    Qt.Key.Key_End: "end",
+    Qt.Key.Key_PageUp: "page up",
+    Qt.Key.Key_PageDown: "page down",
+    Qt.Key.Key_Insert: "insert",
+    Qt.Key.Key_Delete: "delete",
+    Qt.Key.Key_Backspace: "backspace",
+    Qt.Key.Key_Tab: "tab",
+    Qt.Key.Key_Space: "space",
+    Qt.Key.Key_Return: "enter",
+    Qt.Key.Key_Enter: "enter",
+    Qt.Key.Key_Escape: "esc",
+}
+FOCUS_NAVIGATION_HOTKEY_KEYS = {Qt.Key.Key_Left, Qt.Key.Key_Right, Qt.Key.Key_Up, Qt.Key.Key_Down}
 
 
 def _validate_and_save_changes(
@@ -574,14 +594,14 @@ class QHotkeyWidget(QWidget):
         self.setLayout(layout)
 
     def reset_values(self, current_value):
-        self.open_picker_button.setText(current_value)
+        self.open_picker_button.setText(current_value or DISABLED_HOTKEY_TEXT)
 
     def _launch_hotkey_dialog(self, model, section_header, config_key):
-        hotkey_dialog = HotkeyListenerDialog(self)
+        hotkey_dialog = HotkeyListenerDialog(self, getattr(model, config_key))
         if hotkey_dialog.exec():
             new_hotkey = hotkey_dialog.get_hotkey()
-            if new_hotkey and _validate_and_save_changes(model, section_header, config_key, new_hotkey):
-                self.open_picker_button.setText(new_hotkey)
+            if _validate_and_save_changes(model, section_header, config_key, new_hotkey):
+                self.reset_values(new_hotkey)
 
 
 class HotkeyListenerDialog(QDialog):
@@ -595,7 +615,7 @@ class HotkeyListenerDialog(QDialog):
         self.label = QLabel("Press the key or combination of keys you\nwant to use as a hotkey, then click save.", self)
         self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.hotkey_label = QLabel(self.hotkey, self)
+        self.hotkey_label = QLabel(self.hotkey or DISABLED_HOTKEY_TEXT, self)
         self.hotkey_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.layout.addWidget(self.label)
@@ -603,15 +623,34 @@ class HotkeyListenerDialog(QDialog):
 
         self.button_layout = QHBoxLayout()
         self.save_button = QPushButton("Save", self)
+        self.clear_button = QPushButton("Clear", self)
         self.cancel_button = QPushButton("Cancel", self)
 
         self.save_button.clicked.connect(self.accept)
+        self.clear_button.clicked.connect(self._clear_hotkey)
         self.cancel_button.clicked.connect(self.reject)
+        for button in (self.save_button, self.clear_button, self.cancel_button):
+            button.installEventFilter(self)
 
         self.button_layout.addWidget(self.save_button)
+        self.button_layout.addWidget(self.clear_button)
         self.button_layout.addWidget(self.cancel_button)
 
         self.layout.addLayout(self.button_layout)
+
+    def _clear_hotkey(self):
+        self.hotkey = ""
+        self.hotkey_label.setText(DISABLED_HOTKEY_TEXT)
+
+    def eventFilter(self, watched, event):
+        if (
+            watched in {self.save_button, self.clear_button, self.cancel_button}
+            and event.type() == QEvent.Type.KeyPress
+            and event.key() in FOCUS_NAVIGATION_HOTKEY_KEYS
+        ):
+            self.keyPressEvent(event)
+            return True
+        return super().eventFilter(watched, event)
 
     def keyPressEvent(self, event):
         modifiers = []
@@ -628,6 +667,8 @@ class HotkeyListenerDialog(QDialog):
         # Handle function keys
         if Qt.Key.Key_F1 <= key <= Qt.Key.Key_F35:
             non_mod_key = f"f{key - Qt.Key.Key_F1 + 1}"
+        elif key in SPECIAL_HOTKEY_NAMES:
+            non_mod_key = SPECIAL_HOTKEY_NAMES[key]
 
         # Handle regular keys
         else:
@@ -639,7 +680,7 @@ class HotkeyListenerDialog(QDialog):
         hotkey_str = "+".join(parts)
 
         self.hotkey = hotkey_str
-        self.hotkey_label.setText(hotkey_str)
+        self.hotkey_label.setText(hotkey_str or DISABLED_HOTKEY_TEXT)
 
     def get_hotkey(self):
         return self.hotkey

--- a/src/scripts/handler.py
+++ b/src/scripts/handler.py
@@ -19,6 +19,7 @@ import src.scripts.vision_mode_fast
 import src.scripts.vision_mode_with_highlighting
 import src.tts
 from src.cam import Cam
+from src.config.helper import to_keyboard_hotkey
 from src.config.loader import IniConfigLoader
 from src.config.settings_models import (
     IS_HOTKEY_KEY,
@@ -234,7 +235,9 @@ class ScriptHandler:
                 keyboard.remove_hotkey(handle)
 
     def _register_hotkey(self, hotkey: str, callback: Callable[[], None]) -> None:
-        self._hotkey_handles.append(keyboard.add_hotkey(hotkey, callback))
+        if not hotkey:
+            return
+        self._hotkey_handles.append(keyboard.add_hotkey(to_keyboard_hotkey(hotkey), callback))
 
     def setup_key_binds(self):
         if sys.platform == "darwin":

--- a/tests/config/helper_test.py
+++ b/tests/config/helper_test.py
@@ -1,6 +1,7 @@
 import pytest
 
-from src.config.helper import singleton, str_to_int_list, validate_hotkey
+from src.config.helper import singleton, str_to_int_list, to_keyboard_hotkey, validate_hotkey
+from src.config.settings_models import AdvancedOptionsModel
 
 
 class TestKeyMustExist:
@@ -11,10 +12,42 @@ class TestKeyMustExist:
     def test_modifier_key_works(self):
         assert validate_hotkey("shift+a")
 
+    @pytest.mark.parametrize("hotkey", ["left", "right", "up", "down", "shift+left", "ctrl+right", "alt+up"])
+    def test_arrow_keys_work(self, hotkey):
+        assert validate_hotkey(hotkey, allow_empty=True)
+
+    def test_layout_sensitive_key_uses_scan_code_for_keyboard_hook(self, monkeypatch):
+        umlaut_key = "ctrl+\N{LATIN SMALL LETTER O WITH DIAERESIS}"
+
+        def fake_parse_hotkey(hotkey):
+            return {umlaut_key: (((29, 57373), (39,)),), "^": (((41, -255),),)}[hotkey]
+
+        monkeypatch.setattr("src.config.helper.keyboard.parse_hotkey", fake_parse_hotkey)
+
+        assert to_keyboard_hotkey(umlaut_key) == (((29, 57373), (39,)),)
+        assert to_keyboard_hotkey("^") == (((41,),),)
+
+    def test_empty_key_disables_optional_hotkey(self):
+        assert not validate_hotkey("", allow_empty=True)
+
+    def test_empty_key_fails_by_default(self):
+        with pytest.raises(ValueError, match="Can only normalize non-empty string names."):
+            validate_hotkey("")
+
     def test_non_existing_key(self):
         # Test for a non-existing key
         with pytest.raises(ValueError, match="Key 'non_existing_key' is not mapped to any known key."):
             validate_hotkey("non_existing_key")
+
+    def test_empty_keys_are_excluded_from_unique_hotkey_check(self):
+        model = AdvancedOptionsModel(exit_key="", toggle_paragon_overlay="")
+
+        assert not model.exit_key
+        assert not model.toggle_paragon_overlay
+
+    def test_non_empty_keys_must_still_be_unique(self):
+        with pytest.raises(ValueError, match="hotkeys must be unique"):
+            AdvancedOptionsModel(exit_key="f10", toggle_paragon_overlay="f10")
 
 
 class TestSingletonDecorator:

--- a/tests/gui/config_tab_test.py
+++ b/tests/gui/config_tab_test.py
@@ -1,0 +1,36 @@
+import pytest
+from PyQt6.QtCore import QEvent, Qt
+from PyQt6.QtGui import QKeyEvent
+from PyQt6.QtWidgets import QApplication
+
+from src.gui.config_tab import HotkeyListenerDialog
+
+
+@pytest.fixture
+def q_application():
+    return QApplication.instance() or QApplication([])
+
+
+def test_arrow_key_on_hotkey_dialog_button_sets_hotkey(q_application):
+    assert q_application is not None
+    dialog = HotkeyListenerDialog(hotkey="f8")
+    event = QKeyEvent(QEvent.Type.KeyPress, Qt.Key.Key_Left, Qt.KeyboardModifier.ShiftModifier)
+
+    try:
+        assert dialog.eventFilter(dialog.save_button, event)
+        assert dialog.get_hotkey() == "shift+left"
+        assert dialog.hotkey_label.text() == "shift+left"
+    finally:
+        dialog.deleteLater()
+
+
+def test_non_arrow_key_on_hotkey_dialog_button_keeps_default_button_handling(q_application):
+    assert q_application is not None
+    dialog = HotkeyListenerDialog(hotkey="f8")
+    event = QKeyEvent(QEvent.Type.KeyPress, Qt.Key.Key_Tab, Qt.KeyboardModifier.NoModifier)
+
+    try:
+        assert not dialog.eventFilter(dialog.save_button, event)
+        assert dialog.get_hotkey() == "f8"
+    finally:
+        dialog.deleteLater()


### PR DESCRIPTION
for more information ask schoof on discord, he had problems with those keys

Root cause: Hotkey handling relied on keyboard character names, which can mis-handle German/dead keys like ä, ö, and ^. Arrow keys also reached focused dialog buttons first, so Qt used them for focus navigation instead of recording them as hotkeys.

Code change: Added shared hotkey normalization for validation/registration, allow disabling optional advanced hotkeys, added picker support for special keys, and intercept arrow-key presses on hotkey dialog buttons.

Behavior impact: Users can bind German layout keys, arrow keys, and modifier combos like shift+left, and can clear optional action hotkeys.