### PR TITLE
Fixed issue that was causing crashes when hotkeys were pressed when Diablo 4 was not the main screen. Also, Paragon and Info overlays will now auto hide if Diablo 4 is not the main screen.

### DIFF
--- a/src/gui/importer/maxroll.py
+++ b/src/gui/importer/maxroll.py
@@ -5,7 +5,6 @@ import re
 import lxml.html
 
 import src.logger
-from gui.importer.gui_common import add_mythics_to_filters
 from src.config.profile_models import (
     AffixFilterCountModel,
     AffixFilterModel,
@@ -15,6 +14,7 @@ from src.config.profile_models import (
 )
 from src.dataloader import Dataloader
 from src.gui.importer.gui_common import (
+    add_mythics_to_filters,
     add_to_profiles,
     build_default_profile_file_name,
     fix_offhand_type,

--- a/src/paragon_overlay.py
+++ b/src/paragon_overlay.py
@@ -36,6 +36,7 @@ from src.gui.importer.gui_common import (
     TRANSPARENT_KEY,
 )
 from src.item.filter import Filter
+from src.utils.window import WindowSpec, is_window_foreground
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -447,6 +448,7 @@ class ParagonOverlay(tk.Toplevel):
         self._config_loader.register_change_listener(self._config_listener)
         self._cam = Cam()
         self._res = ResManager()
+        self._win_spec = WindowSpec(self._config_loader.advanced_options.process_name)
         self.builds = list(builds)
 
         # Restore the previously selected build by its persisted identity first.
@@ -647,6 +649,16 @@ class ParagonOverlay(tk.Toplevel):
     def _poll_window_state(self) -> None:
         """Re-apply geometry when the tracked game window changes size or ROI."""
         try:
+            is_fgrnd = is_window_foreground(self._win_spec)
+            if is_fgrnd and not self.winfo_viewable():
+                self.deiconify()
+                self.lift()
+            elif not is_fgrnd and self.winfo_viewable():
+                self.withdraw()
+
+            if not is_fgrnd:
+                return
+
             roi, res = self._get_cam_roi(), self._get_resolution()
             if roi != self._last_roi or res != self._last_res:
                 self._last_roi, self._last_res = roi, res

--- a/src/scripts/handler.py
+++ b/src/scripts/handler.py
@@ -39,7 +39,7 @@ from src.ui.char_inventory import CharInventory
 from src.ui.stash import Stash
 from src.utils.custom_mouse import mouse
 from src.utils.process_handler import kill_thread, safe_exit
-from src.utils.window import screenshot
+from src.utils.window import WindowSpec, is_window_foreground, screenshot
 
 LOGGER = logging.getLogger(__name__)
 
@@ -95,6 +95,7 @@ class ScriptHandler:
         self._runtime_config_lock = threading.RLock()
         self._manual_restart_warning = False
         self._config = IniConfigLoader()
+        self._win_spec = WindowSpec(self._config.advanced_options.process_name)
         self._language = self._config.general.language
         self._log_level = self._config.advanced_options.log_lvl.value.upper()
         self.vision_mode = self._create_vision_mode(self._config.general.vision_mode_type)
@@ -277,8 +278,12 @@ class ScriptHandler:
             with suppress(KeyError, ValueError):
                 keyboard.remove_hotkey(handle)
 
-    def _register_hotkey(self, hotkey: str, callback: Callable[[], None]) -> None:
-        self._hotkey_handles.append(keyboard.add_hotkey(hotkey, callback))
+    def _register_hotkey(self, hotkey: str, callback: Callable[[], None], check_focus: bool = True) -> None:
+        def wrapped_callback():
+            if not check_focus or is_window_foreground(self._win_spec):
+                callback()
+
+        self._hotkey_handles.append(keyboard.add_hotkey(hotkey, wrapped_callback))
 
     def setup_key_binds(self):
         if sys.platform == "darwin":
@@ -288,7 +293,7 @@ class ScriptHandler:
         config = self._config
         advanced_options = config.advanced_options
         self._register_hotkey(advanced_options.run_vision_mode, lambda: self.run_vision_mode())
-        self._register_hotkey(advanced_options.exit_key, lambda: self._graceful_exit())
+        self._register_hotkey(advanced_options.exit_key, lambda: self._graceful_exit(), check_focus=False)
         self._register_hotkey(advanced_options.toggle_paragon_overlay, lambda: self.toggle_paragon_overlay())
         self._register_hotkey(advanced_options.info_overlay, lambda: self.toggle_info_overlay())
         self._register_hotkey(config.char.inventory, lambda: InventoryExpTracker().on_inventory_open())

--- a/src/scripts/info_overlay.py
+++ b/src/scripts/info_overlay.py
@@ -22,6 +22,7 @@ from src.gui.importer.gui_common import ACCENT_BLUE, ACCENT_GOLD, ACCENT_GREEN, 
 from src.scripts.common import get_filter_colors
 from src.tts import Publisher
 from src.utils.custom_mouse import mouse
+from src.utils.window import WindowSpec, is_window_foreground
 
 LOGGER = logging.getLogger(__name__)
 
@@ -157,8 +158,13 @@ def _hover_experience_balance(info_config: dict[str, Any]):
 
 def request_close():
     with _OVERLAY_LOCK:
-        if _OVERLAY_INSTANCE is not None:
-            _OVERLAY_INSTANCE.after(0, lambda: _OVERLAY_INSTANCE.master.destroy())
+        if _OVERLAY_INSTANCE is not None and _OVERLAY_INSTANCE.winfo_exists():
+            try:
+                # Ensure destruction happens on the Tk thread
+                _OVERLAY_INSTANCE.after(0, _OVERLAY_INSTANCE.destroy)
+            except Exception:
+                with suppress(Exception):
+                    _OVERLAY_INSTANCE.master.destroy()
 
 
 @singleton
@@ -358,6 +364,9 @@ class BossTimerOverlay(tk.Toplevel):
         self.wm_attributes("-transparentcolor", TRANSPARENT_KEY)
         self.configure(bg=TRANSPARENT_KEY)
 
+        self._win_spec = WindowSpec(IniConfigLoader().advanced_options.process_name)
+        self._after_ids: list[str] = []
+        self._closing = False
         self._gold_initialized = False
         self._exp_initialized = False
         self._menu_vars = []  # Initialize here to store tk.Variable instances
@@ -378,9 +387,28 @@ class BossTimerOverlay(tk.Toplevel):
 
     def destroy(self):
         """Perform cleanup and unsubscribe from stats on destruction."""
+        if self._closing:
+            return
+        self._closing = True
+
+        # Cancel all pending after calls to avoid Tcl_AsyncDelete errors
+        for after_id in self._after_ids:
+            with suppress(Exception):
+                self.after_cancel(after_id)
+        self._after_ids.clear()
+
+        if self._settings_popup and self._settings_popup.winfo_exists():
+            self._settings_popup.destroy()
+        self._close_all_submenus()
+
         self._session_stats.unsubscribe()
         self._menu_vars.clear()
-        super().destroy()
+
+        # Stop the mainloop and destroy the root (master)
+        with suppress(tk.TclError, Exception):
+            self.master.quit()
+            self.master.destroy()
+
         with _OVERLAY_LOCK:
             global _OVERLAY_INSTANCE
             if _OVERLAY_INSTANCE is self:
@@ -1413,8 +1441,21 @@ class BossTimerOverlay(tk.Toplevel):
             LOGGER.error(f"Failed to auto-sync from helltides.com: {e}")
 
     def _update_timers(self):
-        if not self.winfo_exists():
+        if self._closing or not self.winfo_exists():
             return
+
+        # Toggle visibility based on window focus
+        focused = is_window_foreground(self._win_spec)
+        if focused and self.state() == "withdrawn":
+            self.deiconify()
+        elif not focused and self.state() != "withdrawn":
+            self.withdraw()
+
+        if not focused:
+            aid = self.after(1000, self._update_timers)
+            self._after_ids.append(aid)
+            return
+
         now = datetime.datetime.now(datetime.UTC)
         self._flash_toggle = not self._flash_toggle
         colors = get_filter_colors()
@@ -1512,7 +1553,8 @@ class BossTimerOverlay(tk.Toplevel):
                     m, s = divmod(int(remaining), 60)
                     self.next_scan_value_label.config(text=f"{m}m {s}s" if m > 0 else f"{s}s")
 
-        self.after(1000, self._update_timers)
+        aid = self.after(1000, self._update_timers)
+        self._after_ids.append(aid)
 
     def update_stats(
         self,
@@ -1523,33 +1565,41 @@ class BossTimerOverlay(tk.Toplevel):
         t2l: str | None = None,
     ):
         """Update the gold and experience statistics display."""
-        repack_needed = False
-        if gph is not None and self.capture_gold_stats:
-            self.gph_value_label.config(text=f"{gph:,}")
-            if not self._gold_initialized:
-                self._gold_initialized = True
-                repack_needed = True
-        if total_gained is not None and self.capture_gold_stats:
-            self.total_gained_value_label.config(text=f"{total_gained:,}")
-            if not self._gold_initialized:
-                self._gold_initialized = True
-                repack_needed = True
-        if eph is not None and self.capture_exp_stats:
-            self.eph_value_label.config(text=f"{eph:,}")
-            if not self._exp_initialized:
-                self._exp_initialized = True
-                repack_needed = True
-        if total_exp is not None and self.capture_exp_stats:
-            self.total_exp_value_label.config(text=f"{total_exp:,}")
-            if not self._exp_initialized:
-                self._exp_initialized = True
-                repack_needed = True
-        if t2l is not None and self.capture_exp_stats:
-            self.t2l_value_label.config(text=t2l)
 
-        if repack_needed:
-            self._repack()
-            self.update_idletasks()
+        def _do_update():
+            if self._closing or not self.winfo_exists():
+                return
+            repack_needed = False
+            if gph is not None and self.capture_gold_stats:
+                self.gph_value_label.config(text=f"{gph:,}")
+                if not self._gold_initialized:
+                    self._gold_initialized = True
+                    repack_needed = True
+            if total_gained is not None and self.capture_gold_stats:
+                self.total_gained_value_label.config(text=f"{total_gained:,}")
+                if not self._gold_initialized:
+                    self._gold_initialized = True
+                    repack_needed = True
+            if eph is not None and self.capture_exp_stats:
+                self.eph_value_label.config(text=f"{eph:,}")
+                if not self._exp_initialized:
+                    self._exp_initialized = True
+                    repack_needed = True
+            if total_exp is not None and self.capture_exp_stats:
+                self.total_exp_value_label.config(text=f"{total_exp:,}")
+                if not self._exp_initialized:
+                    self._exp_initialized = True
+                    repack_needed = True
+            if t2l is not None and self.capture_exp_stats:
+                self.t2l_value_label.config(text=t2l)
+
+            if repack_needed:
+                self._repack()
+                self.update_idletasks()
+
+        if not self._closing:
+            aid = self.after(0, _do_update)
+            self._after_ids.append(aid)
 
 
 def run_boss_timer_overlay():


### PR DESCRIPTION
I have added the hotkey check in handler using the already provided code in window.py. Paragon Overlay and Info Overlay now both disappear when diablo 4 is not in the foreground. I added improvement logic to thread destruction in info_overlay.