### PR TITLE
(BugFix) Fixed issue where overlays on some multi-monitor setups would end up on the wrong monitor

### DIFF
--- a/src/paragon_overlay.py
+++ b/src/paragon_overlay.py
@@ -1540,9 +1540,10 @@ class ParagonOverlay(tk.Toplevel):
     def _get_cam_roi(self) -> tuple[int, int, int, int] | None:
         """Return the tracked game window ROI when the camera module exposes one."""
         try:
-            return (
-                (int(r[0]), int(r[1]), int(r[2]), int(r[3])) if (r := getattr(self._cam, "window_roi", None)) else None
-            )
+            r = getattr(self._cam, "window_roi", None)
+            if not r or r.get("width", 0) <= 0:
+                return None
+            return (int(r["left"]), int(r["top"]), int(r["width"]), int(r["height"]))
         except Exception:
             return None
 

--- a/src/scripts/info_overlay.py
+++ b/src/scripts/info_overlay.py
@@ -372,9 +372,11 @@ class BossTimerOverlay(tk.Toplevel):
         self._menu_vars = []  # Initialize here to store tk.Variable instances
         self._settings_popup = None
         self._last_menu_pos = (100, 100)
+        self._cam = Cam()
 
         self.settings = load_info_settings()
         self._apply_loaded_settings()
+
         self._flash_toggle = False
         self._setup_ui()
         self._bind_events()
@@ -415,7 +417,11 @@ class BossTimerOverlay(tk.Toplevel):
                 _OVERLAY_INSTANCE = None
 
     def _apply_loaded_settings(self):
-        self.x, self.y = self.settings["x"], self.settings["y"]
+        # Transition to relative coordinates: Add the current game window offset to the saved position.
+        roi = self._cam.window_roi
+        offset_x = roi.get("left", 0) if roi else 0
+        offset_y = roi.get("top", 0) if roi else 0
+        self.x, self.y = self.settings["x"] + offset_x, self.settings["y"] + offset_y
         self.font_size = self.settings["font_size"]
         self.next_boss_name = self.settings["next_boss_name"]
         self.orientation = self.settings["orientation"]
@@ -441,9 +447,12 @@ class BossTimerOverlay(tk.Toplevel):
         self._exp_initialized = self.capture_exp_stats and stats.last_exp is not None
 
     def _save_settings(self):
+        roi = self._cam.window_roi
+        offset_x = roi.get("left", 0) if roi else 0
+        offset_y = roi.get("top", 0) if roi else 0
         updates: dict[str, Any] = {
-            "x": self.winfo_x(),
-            "y": self.winfo_y(),
+            "x": self.winfo_x() - offset_x,
+            "y": self.winfo_y() - offset_y,
             "font_size": self.font_size,
             "wb_reference": self.wb_reference,
             "next_boss_name": self.next_boss_name,


### PR DESCRIPTION
This was the core fix for secondary monitors.

Paragon Overlay: Fixed a bug in _get_cam_roi where the code tried to access window data as a list (e.g., r[0]) instead of a dictionary (e.g., r["left"]). Fixing this allowed the overlay to correctly retrieve the game window's absolute screen coordinates.
Info Overlay: Converted from Absolute to Relative coordinates.
Saving: When you save the position, the script subtracts the game's current monitor offset (winfo_x() - offset_x).
Loading: When it opens, it adds the current game monitor offset back to the saved value.
Result: The Info Overlay now "belongs" to the Diablo IV window. If you move D4 to a different monitor, the overlay follows it automatically on the next launch, regardless of which monitor Windows considers "Primary."