### PR TITLE
Paragon Overlay Menu Fix and Stash Tabs/tabs to filter fix

### DIFF
--- a/src/config/settings_models.py
+++ b/src/config/settings_models.py
@@ -290,7 +290,7 @@ class GeneralModel(_IniBaseModel):
         json_schema_extra={CATEGORY_KEY: SettingsCategory.SYSTEM},
     )
     check_chest_tabs: list[int] = Field(
-        default=[0, 1, 2, 3, 4, 5, 6],
+        default=[0, 1],
         description="Which stash tabs to check. Note: All tabs available (6 or 7) must be unlocked!",
         title="Stash Tabs to Filter",
         json_schema_extra={CATEGORY_KEY: SettingsCategory.STASH},

--- a/src/config/settings_models.py
+++ b/src/config/settings_models.py
@@ -290,7 +290,7 @@ class GeneralModel(_IniBaseModel):
         json_schema_extra={CATEGORY_KEY: SettingsCategory.SYSTEM},
     )
     check_chest_tabs: list[int] = Field(
-        default=[0, 1],
+        default=[0, 1, 2, 3, 4, 5, 6],
         description="Which stash tabs to check. Note: All tabs available (6 or 7) must be unlocked!",
         title="Stash Tabs to Filter",
         json_schema_extra={CATEGORY_KEY: SettingsCategory.STASH},
@@ -403,13 +403,22 @@ class GeneralModel(_IniBaseModel):
 
     @field_validator("check_chest_tabs", mode="before")
     @classmethod
-    def check_chest_tabs_index(cls, v: str) -> list[int]:
+    def check_chest_tabs_index(cls, v: object) -> list[int]:
         if isinstance(v, str):
-            v = v.split(",")
-        elif not isinstance(v, list):
-            msg = "must be a list or a string"
-            raise ValueError(msg)
-        return sorted([int(x) - 1 for x in v])
+            return sorted([int(x.strip()) - 1 for x in v.split(",") if x.strip()])
+        if isinstance(v, list):
+            # Subtract 1 only if the element is a string (external 1-based format)
+            return sorted([int(x) - 1 if isinstance(x, str) else int(x) for x in v])
+        msg = "must be a list or a string"
+        raise ValueError(msg)
+
+    @model_validator(mode="after")
+    def validate_stash_tabs(self) -> GeneralModel:
+        # Constrain check_chest_tabs to the range [0, max_stash_tabs - 1]
+        new_tabs = sorted({t for t in self.check_chest_tabs if 0 <= t < self.max_stash_tabs})
+        if new_tabs != self.check_chest_tabs:
+            self.__dict__["check_chest_tabs"] = new_tabs
+        return self
 
     @field_validator("max_stash_tabs")
     @classmethod

--- a/src/gui/settings_tab.py
+++ b/src/gui/settings_tab.py
@@ -646,7 +646,7 @@ class QChestTabWidget(QWidget):
             self.layout.removeWidget(cb)
             cb.deleteLater()
 
-        max_tabs = getattr(self.model, "max_stash_tabs", 7)
+        max_tabs = self.model.max_stash_tabs
         for x in range(max_tabs):
             stash_checkbox = CheckmarkCheckBox(self)
             stash_checkbox.setText(str(x + 1))

--- a/src/gui/settings_tab.py
+++ b/src/gui/settings_tab.py
@@ -350,7 +350,11 @@ class ConfigTab(QWidget):
         elif config_key == "max_stash_tabs":
 
             def on_tabs_changed(val):
-                _validate_and_save_changes(model, section_config_header, config_key, val)
+                if _validate_and_save_changes(model, section_config_header, config_key, val):
+                    # Refresh the stash tabs widget to show the correct number of checkboxes
+                    tabs_widget = self.model_to_parameter_value_map.get(f"{section_config_header}.check_chest_tabs")
+                    if isinstance(tabs_widget, QChestTabWidget):
+                        tabs_widget.reset_values(model.check_chest_tabs)
 
             parameter_value_widget = SegmentedControl(["6", "7"], str(config_value), on_tabs_changed)
         elif config_key in {"move_to_inv_item_type", "move_to_stash_item_type"}:
@@ -627,25 +631,32 @@ class IgnoreScrollWheelComboBox(QComboBox):
 class QChestTabWidget(QWidget):
     def __init__(self, model, section_header, config_key, chest_tab_config: list[int], max_chest_tabs):
         super().__init__()
+        self.model = model
+        self.section_header = section_header
+        self.config_key = config_key
         self.all_checkboxes: list[CheckmarkCheckBox] = []
-        stash_checkbox_layout = QHBoxLayout()
-        stash_checkbox_layout.setContentsMargins(0, 0, 0, 0)
-        for x in range(1, max_chest_tabs + 1):
+        self.layout = QHBoxLayout(self)
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        self.reset_values(chest_tab_config)
+
+    def reset_values(self, chest_tab_config: list[int]):
+        # Clear existing checkboxes
+        while self.all_checkboxes:
+            cb = self.all_checkboxes.pop()
+            self.layout.removeWidget(cb)
+            cb.deleteLater()
+
+        max_tabs = getattr(self.model, "max_stash_tabs", 7)
+        for x in range(max_tabs):
             stash_checkbox = CheckmarkCheckBox(self)
             stash_checkbox.setText(str(x + 1))
             self.all_checkboxes.append(stash_checkbox)
-            if x in chest_tab_config:  # type: ignore[operator]
+            if x in chest_tab_config:
                 stash_checkbox.setChecked(True)
             stash_checkbox.stateChanged.connect(
-                lambda: self._save_changes_on_box_change(model, section_header, config_key)
+                lambda: self._save_changes_on_box_change(self.model, self.section_header, self.config_key)
             )
-            stash_checkbox_layout.addWidget(stash_checkbox)
-
-        self.setLayout(stash_checkbox_layout)
-
-    def reset_values(self, chest_tab_config: list[int]):
-        for check_box in self.all_checkboxes:  # type: ignore[attr-defined]
-            check_box.setChecked(int(check_box.text()) - 1 in chest_tab_config)
+            self.layout.addWidget(stash_checkbox)
 
     def _save_changes_on_box_change(self, model, section_header, config_key):
         active_tabs = [check_box.text() for check_box in self.all_checkboxes if check_box.isChecked()]

--- a/src/paragon_overlay.py
+++ b/src/paragon_overlay.py
@@ -1529,7 +1529,7 @@ class ParagonOverlay(tk.Toplevel):
                     ImageDraw.Draw(i).text((1, 1), "🔒" if locked else "🔓", font=fnt)
                 b = io.BytesIO()
                 i.save(b, format="PNG")
-                return tk.PhotoImage(data=base64.b64encode(b.getvalue()))
+                return tk.PhotoImage(master=self, data=base64.b64encode(b.getvalue()))
 
             self._lock_img_cache = {True: _mk(locked=True), False: _mk(locked=False)}
         except OSError, ValueError, tk.TclError:


### PR DESCRIPTION
The  paragon overlay menu was tossing an error when trying to open. Stash tabs to filter was also mislabeled as 2-8. Now its properly 1-6 or 1-7 depending on what you have set as your max stash tabs.