### PR TITLE
(Paragon Overlay) When the overlay is locked, mouse clicks on the green squares are no longer blocked by the overlay

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@ import concurrent.futures
 
 TP = concurrent.futures.ThreadPoolExecutor()
 
-__version__ = "9.2.5"
+__version__ = "9.2.6"

--- a/src/paragon_overlay.py
+++ b/src/paragon_overlay.py
@@ -632,7 +632,7 @@ class ParagonOverlay(tk.Toplevel):
 
         self.btn_settings = _tk_btn(
             btn_cont,
-            text="ParagonOverlay⚙ ▼",
+            text="Settings⚙ ▼",
             cmd=self._show_settings_dropdown,
             font=("Segoe UI", int(FS_BUTTON * self._cfg.ui_scale), "bold"),
             padx=int(10 * self._cfg.ui_scale),

--- a/src/paragon_overlay.py
+++ b/src/paragon_overlay.py
@@ -39,6 +39,10 @@ from src.gui.importer.gui_common import (
 from src.item.filter import Filter
 from src.utils.window import WindowSpec, is_self_foreground, is_window_foreground
 
+if sys.platform == "win32":
+    import win32con
+    import win32gui
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
@@ -529,6 +533,8 @@ class ParagonOverlay(tk.Toplevel):
         self._warmup_after_id = self.after(600, self._warmup_settings_assets)
         self.after(self._cfg.poll_ms, self._poll_window_state)
         self.after(50, self._poll_close_request)
+        if sys.platform == "win32":
+            self.after(100, self._poll_click_through)
 
     def _apply_dpi_scaling(self) -> None:
         """Apply DPI-aware sizing before widgets are created."""
@@ -745,6 +751,8 @@ class ParagonOverlay(tk.Toplevel):
         """Enable or disable all grid movement and zoom controls."""
         self._cfg.grid_locked = not self._cfg.grid_locked
         self._persist_state()
+        if sys.platform == "win32":
+            self._update_click_through()
 
     def _toggle_gold_frames(self) -> None:
         """Toggle the optional gold accent color override for all frames."""
@@ -1575,6 +1583,80 @@ class ParagonOverlay(tk.Toplevel):
         if self._dragging_grid:
             self._dragging_grid = False
             self._persist_state()
+
+    def _set_click_through(self, *, enabled: bool) -> None:
+        """Set WS_EX_TRANSPARENT style on the window handle to enable/disable click-through.
+
+        Args:
+            enabled: True to enable click-through, False to disable it.
+        """
+        if sys.platform != "win32":
+            return
+        try:
+            hwnd = win32gui.GetAncestor(int(self.winfo_id()), win32con.GA_ROOT)
+            styles = win32gui.GetWindowLong(hwnd, win32con.GWL_EXSTYLE)
+            new_styles = styles | win32con.WS_EX_TRANSPARENT if enabled else styles & ~win32con.WS_EX_TRANSPARENT
+            if new_styles != styles:
+                LOGGER.debug("Paragon overlay click-through changing to: %s", enabled)
+                win32gui.SetWindowLong(hwnd, win32con.GWL_EXSTYLE, new_styles)
+                win32gui.SetWindowPos(
+                    hwnd,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    win32con.SWP_NOMOVE | win32con.SWP_NOSIZE | win32con.SWP_NOZORDER | win32con.SWP_FRAMECHANGED,
+                )
+        except tk.TclError, AttributeError, win32gui.error:
+            LOGGER.debug("Failed to set click through style", exc_info=True)
+
+    def _update_click_through(self) -> None:
+        """Update click-through style depending on grid lock and mouse position."""
+        if sys.platform != "win32":
+            return
+
+        try:
+            if not self._cfg.grid_locked:
+                self._set_click_through(enabled=False)
+                return
+
+            if not self.winfo_viewable():
+                return
+
+            px, py = self.winfo_pointerxy()
+            rx = self.winfo_rootx()
+            ry = self.winfo_rooty()
+            rw = self._cfg.panel_w
+            rh = self.winfo_height()
+
+            popup_active = _is_alive(getattr(self, "_settings_popup", None), mapped=True) or _is_alive(
+                getattr(self, "_build_popup", None), mapped=True
+            )
+
+            over_panel = (rx <= px < rx + rw) and (ry <= py < ry + rh)
+            target_enabled = not (over_panel or popup_active)
+            LOGGER.debug(
+                "Paragon overlay click-through debug: mouse=(%s, %s), root=(%s, %s), rw=%s, rh=%s, over_panel=%s, popup_active=%s, target_enabled=%s",
+                px,
+                py,
+                rx,
+                ry,
+                rw,
+                rh,
+                over_panel,
+                popup_active,
+                target_enabled,
+            )
+            self._set_click_through(enabled=target_enabled)
+        except (tk.TclError, AttributeError, ValueError, TypeError, win32gui.error) as e:
+            LOGGER.debug("Failed to update click-through state: %s", e)
+
+    def _poll_click_through(self) -> None:
+        """Poll the click-through state frequently when window is viewable."""
+        if sys.platform == "win32" and _is_alive(self):
+            self._update_click_through()
+            self.after(100, self._poll_click_through)
 
     # --- GEOMETRY & RENDERING ---
 


### PR DESCRIPTION
Root Cause: In Tkinter on Windows, winfo_id() returns the window handle (HWND) of the internal widget frame instead of the outermost OS wrapper window. Applying extended style changes (WS_EX_TRANSPARENT) to this child handle has no effect because the parent wrapper still catches mouse clicks. Furthermore, Windows caches the styles of active windows; changes do not apply immediately unless forced.

Code Change: Updated src/paragon_overlay.py to:

Retrieve the outermost top-level wrapper HWND using win32gui.GetAncestor(int(self.winfo_id()), win32con.GA_ROOT).
Dynamically toggle the WS_EX_TRANSPARENT style on this wrapper window in a 100ms polling loop, only when the grid is locked and the mouse cursor is not hovering over the control panel or active popup sub-menus.
Force immediate application of the style changes using win32gui.SetWindowPos with the SWP_FRAMECHANGED flag (preserving position/size/Z-order).
Behavior Impact: When the grid is locked, clicks on the green boxes, lines, and transparent canvas pass directly to the game underneath. Hovering the mouse back over the left control panel immediately restores overlay interactivity. Unlocking the grid instantly disables click-through so the overlay can be repositioned.