### PR TITLE
Add dedicated build workflow

### DIFF
--- a/.github/actions/build_zip/action.yml
+++ b/.github/actions/build_zip/action.yml
@@ -1,0 +1,24 @@
+name: Build and zip exe
+
+outputs:
+  version:
+    description: The application version
+    value: ${{ steps.build_zip.outputs.version }}
+  zip_path:
+    description: The path to the versioned ZIP archive
+    value: ${{ steps.build_zip.outputs.zip_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build & Zip exe
+      id: build_zip
+      shell: powershell
+      run: |
+        python build.py
+        $version = python -c "from src import __version__; print(__version__)"
+        $folderName = "d4lf"
+        $zipName = "d4lf_v" + $version
+        Compress-Archive -Path $folderName -DestinationPath "$zipName.zip"
+        echo "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        echo "zip_path=$zipName.zip" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: build
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup env
+        uses: ./.github/actions/setup_env
+      - name: Build & Zip exe
+        id: build_zip
+        uses: ./.github/actions/build_zip
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: d4lf_v${{ steps.build_zip.outputs.version }}
+          path: ${{ steps.build_zip.outputs.zip_path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,33 +23,27 @@ jobs:
         uses: ./.github/actions/setup_env
       - name: Build & Zip exe
         id: build_zip
-        shell: powershell
-        run: |
-          python build.py
-          $version = python -c "from src import __version__; print(__version__)"
-          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          $folderName = "d4lf"
-          $zipName = "d4lf_v" + $version
-          Compress-Archive -Path $folderName -DestinationPath "$zipName.zip"
+        uses: ./.github/actions/build_zip
       - name: Create Tag
         shell: powershell
         run: |
-          git tag "v${{ env.VERSION }}"
-          git push origin "v${{ env.VERSION }}"
+          git tag "v${{ steps.build_zip.outputs.version }}"
+          git push origin "v${{ steps.build_zip.outputs.version }}"
       - name: Check if beta
         id: check_beta
         shell: powershell
         run: |
-          if ($env:VERSION -like "*beta*" -or $env:VERSION -like "*alpha*") {
+          $version = "${{ steps.build_zip.outputs.version }}"
+          if ($version -like "*beta*" -or $version -like "*alpha*") {
             echo "IS_BETA=true" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
           } else {
             echo "IS_BETA=false" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
           }
       - uses: softprops/action-gh-release@v3
         with:
-          files: d4lf_v*.zip
+          files: ${{ steps.build_zip.outputs.zip_path }}
           generate_release_notes: true
-          name: "v${{ env.VERSION }}"
+          name: "v${{ steps.build_zip.outputs.version }}"
           prerelease: ${{ env.IS_BETA == 'true' }}
-          tag_name: "v${{ env.VERSION }}"
+          tag_name: "v${{ steps.build_zip.outputs.version }}"
           token: "${{ secrets.RELEASE_TOKEN }}"


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a dedicated build workflow and shares the build packaging logic with releases. The main changes are:

- A reusable composite action builds the executable, creates the versioned ZIP, and exposes `version` and `zip_path` outputs.
- A manual Windows build workflow runs setup, invokes the shared build action, and uploads the ZIP artifact.
- The release workflow now uses the shared build action outputs for tag creation, prerelease detection, and release asset upload.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The changed workflow logic is a straightforward extraction of existing release build steps into a shared action plus a new manual build workflow. No current workflow breakage, security issue, or incorrect output handling was identified in the changed files.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the contract-smoke workflow from /home/user/repo by running uv run python trex-artifacts/workflow\_contract\_smoke.py; the run completed with exit code 0 and the log shows all YAML/contract assertions passed with final status PASS, and Windows packaging was intentionally not attempted due to scope.

<a href="https://app.greptile.com/trex/runs/14433780/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/build_zip/action.yml | Adds a reusable composite PowerShell action that builds the executable, zips the output, and exposes version/archive outputs. |
| .github/workflows/build.yml | Adds a manual Windows build workflow that checks out the repo, sets up the existing environment, runs the shared build action, and uploads the ZIP artifact. |
| .github/workflows/release.yml | Refactors the release workflow to consume the shared build action outputs for tagging, prerelease detection, and release asset selection. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Dev as Maintainer
participant Build as Build workflow
participant Release as Release workflow
participant Setup as setup_env action
participant Zip as build_zip action
participant GH as GitHub artifacts/releases

Dev->>Build: workflow_dispatch
Build->>Setup: install uv/Python deps
Build->>Zip: python build.py + Compress-Archive
Zip-->>Build: version, zip_path
Build->>GH: upload artifact

Dev->>Release: workflow_dispatch or merged release PR
Release->>Setup: install uv/Python deps
Release->>Zip: python build.py + Compress-Archive
Zip-->>Release: version, zip_path
Release->>GH: push tag and create release asset
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Dev as Maintainer
participant Build as Build workflow
participant Release as Release workflow
participant Setup as setup_env action
participant Zip as build_zip action
participant GH as GitHub artifacts/releases

Dev->>Build: workflow_dispatch
Build->>Setup: install uv/Python deps
Build->>Zip: python build.py + Compress-Archive
Zip-->>Build: version, zip_path
Build->>GH: upload artifact

Dev->>Release: workflow_dispatch or merged release PR
Release->>Setup: install uv/Python deps
Release->>Zip: python build.py + Compress-Archive
Zip-->>Release: version, zip_path
Release->>GH: push tag and create release asset
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add dedicated build workflow"](https://github.com/d4lfteam/d4lf/commit/af0475bb7df4cd3d58f1b69c70107b063d2ea8c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44229939)</sub>

<!-- /greptile_comment -->