### PR TITLE
feat: add loot filter overrides + add InfinityBuilds missing features

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,6 +6,18 @@
 
 A user-defined loot filtering configuration for one Diablo 4 build. A profile may include at most one stored Paragon payload for the Paragon overlay.
 
+### Loot filter override
+
+A persistent, profile-independent user setting that disables profile-based and ordinary built-in filtering for an item category without changing the active profile. Changes apply to the next evaluated item; non-Mythic items in a disabled category are left untouched and produce no keep, junk, or filtering-statistics outcome. Built-in Mythic always-keep behavior remains active in every category. The profile's rules resume applying when the category is enabled again. Every category is enabled by default.
+
+### Filterable item category
+
+One of the item groups controlled by a loot filter override: Equipment, Sigils, Tributes, Seals, or Charms. Categories are based on the encountered item, not on individual sections of a profile.
+
+### Mythic always-keep rule
+
+The built-in rule that gives Mythic items a keep outcome independently of profile rules. It remains active when the item's filterable item category is disabled and produces the normal keep statistics and actions.
+
 ### Paragon payload
 
 The stored Paragon overlay data attached to a profile. It represents one imported Paragon build, not a collection of alternative builds. A payload may contain multiple progression steps for that build.

--- a/README.md
+++ b/README.md
@@ -135,11 +135,23 @@ Some commonly modified setting sections:
 
 This is where you activate/deactivate your profiles. You can change the order of the profiles as well by dragging on the
 6 dot icon. The top listed profile is what Vision Mode With Highlighting will show squares for when hovering over an
-item so the order can matter. However, if an item matches any profile at all it will be kept.
+item so the order can matter. However, a matching rule produces a keep only when the item's filterable item category is
+enabled; the Mythic always-keep rule still applies.
 
 #### Loot Behavior
 
-Here you can change how we handle items that don't match a filter at all, for example uniques or codex upgrades.
+Here you can change how we handle items that don't match a filter at all, for example uniques or codex upgrades. The
+following loot filter overrides independently control whether D4LF applies profile rules to each filterable item
+category:
+
+- Filter Equipment
+- Filter Sigils
+- Filter Tributes
+- Filter Seals
+- Filter Charms
+
+When an override is disabled, non-Mythic items in that category are left untouched while the active profile rules are
+preserved. Mythic items are always kept by the Mythic always-keep rule.
 
 #### Stash & Transfer
 
@@ -171,7 +183,8 @@ The Profile Editor allows you to edit your profiles. It is still in beta. The Si
 
 ## How to filter / Profiles
 
-All profiles define whitelist filters. If no filter included in your profiles matches the item, it will be discarded.
+All profiles define whitelist filters. If no filter included in your profiles matches an item in an enabled filterable
+item category, it will be discarded. Disabled categories are left untouched, except that Mythics are always kept.
 
 Your config files will be validated on startup and will prevent the program from starting if the structure or syntax is
 incorrect. The error message will provide hints about the specific problem.
@@ -179,9 +192,9 @@ incorrect. The error message will provide hints about the specific problem.
 The following sections will explain each type of filter that you can specify in your profiles. How you define them in
 your YAML files is up to you; you can put all of these into just one file or have a dedicated file for each type of
 filter, or even split the same type of filter over multiple files. Ultimately, all profiles specified in
-the Profiles section of Settings will be used to determine if an item should be kept. If one of the profiles wants to keep the item, it
-will be kept regardless of the other profiles. Similarly, if a filter is missing in all profiles (e.g., there is
-no `Sigils` section in any profile), all corresponding items (in this case, sigils) will be kept.
+the Profiles section of Settings will be used to determine if an item should be kept when its category is enabled. If one
+of the profiles wants to keep the item, it will be kept regardless of the other profiles. Similarly, if a filter is missing in all profiles (e.g., there is
+no `Sigils` section in any profile), all corresponding items (in this case, sigils) will be kept when Sigils filtering is enabled.
 
 ### Affix / Unique Aspect Filter Syntax
 

--- a/prek.toml
+++ b/prek.toml
@@ -26,7 +26,7 @@ repo = "local"
 [[repos]]
 hooks = [{ id = "uv-lock", priority = 4294967294 }]
 repo = "https://github.com/astral-sh/uv-pre-commit"
-rev = "0.11.31"
+rev = "0.11.32"
 
 [[repos]]
 hooks = [
@@ -87,7 +87,7 @@ hooks = [
   { id = "ruff-check", priority = 4294967293, args = ["--fix"] }
 ]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
-rev = "v0.15.22"
+rev = "v0.16.0"
 
 [[repos]]
 hooks = [{ id = "tombi-format", exclude = "^uv.lock", priority = 4294967294 }]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@ import concurrent.futures
 
 TP = concurrent.futures.ThreadPoolExecutor()
 
-__version__ = "10.0.0"
+__version__ = "10.0.1"

--- a/src/app/shell.py
+++ b/src/app/shell.py
@@ -270,7 +270,12 @@ class UnifiedMainWindow(UnifiedWindowLifecycle):
 
     def open_settings_dialog(self):
         set_accent_color(get_filter_colors().matched)
-        self._show_singleton_modal("config", create_settings_window, theme_changed_callback=self.apply_theme)
+        self._show_singleton_modal(
+            "config",
+            create_settings_window,
+            theme_changed_callback=self.apply_theme,
+            force_maximized=self.isMaximized(),
+        )
 
     def open_profile_editor(self, profile_name: str | None = None):
         self._show_singleton_modal(

--- a/src/importing/gui/constants.py
+++ b/src/importing/gui/constants.py
@@ -61,9 +61,9 @@ _CHECKBOX_CONFIGS = (
     ),
     _CheckboxConfig(
         name="export_paragon_checkbox",
-        label="Export Paragon",
+        label="Import Paragon",
         setting="export_paragon",
-        tooltip="Export paragon boards for the paragon overlay?",
+        tooltip="Import paragon boards for the paragon overlay?",
         default="false",
     ),
     _CheckboxConfig(

--- a/src/importing/infinitybuilds/_talisman.py
+++ b/src/importing/infinitybuilds/_talisman.py
@@ -1,0 +1,77 @@
+"""Convert Infinity Builds talisman payloads into ordinary catalog gear inputs."""
+
+from typing import TYPE_CHECKING, cast
+
+from src.importing.conversion import as_string_keyed_mapping as _as_object
+from src.item import Dataloader
+from src.perception import correct_name
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from src.importing.infinitybuilds.models import _CatalogItem, _GearPiece, _RawAffix
+
+
+def _parse_talisman_gear(value: object) -> list[_GearPiece]:
+    raw = _as_object(value)
+    gear: list[_GearPiece] = []
+    seal = raw.get("seal")
+    if isinstance(seal, str):
+        gear.append({"kind": "talisman", "slot": "seal", "itemId": seal})
+    charms = raw.get("charms")
+    for index, charm_id in enumerate(charms if isinstance(charms, list) else []):
+        if not isinstance(charm_id, str):
+            continue
+        gear.append(
+            {
+                "kind": "talisman",
+                "slot": f"charm{index + 1}",
+                "itemId": charm_id,
+                "affixes": _parse_charm_affixes(raw, index),
+            }
+        )
+    return gear
+
+
+def _parse_charm_affixes(raw: dict[str, object], charm_index: int) -> list[_RawAffix]:
+    result: list[_RawAffix] = []
+    affix_ids = _nested_row(raw.get("charmAffixes"), charm_index)
+    values = _nested_row(raw.get("charmAffixValues"), charm_index)
+    greater_flags = _nested_row(raw.get("charmAffixGreater"), charm_index)
+    for affix_index, affix_id in enumerate(affix_ids):
+        if not isinstance(affix_id, str):
+            continue
+        affix: _RawAffix = {"affixId": affix_id}
+        value = _optional_value_at(values, affix_index)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            affix["value"] = value
+        if _optional_value_at(greater_flags, affix_index) is True:
+            affix["greater"] = True
+        result.append(affix)
+    return result
+
+
+def _catalog_items_by_id(items: Sequence[_CatalogItem]) -> dict[str, _CatalogItem]:
+    result = {item["id"]: item for item in items if "id" in item}
+    for item in items:
+        source_id = item.get("sourceId")
+        if source_id:
+            result[source_id.removesuffix(".itm")] = item
+    return result
+
+
+def _charm_set_name(label: str) -> str | None:
+    _, separator, suffix = label.partition(" of ")
+    candidate = correct_name(suffix) if separator else None
+    return candidate if candidate in Dataloader().set_list else None
+
+
+def _nested_row(rows: object, index: int) -> list[object]:
+    if not isinstance(rows, list) or index >= len(rows):
+        return []
+    row = rows[index]
+    return cast("list[object]", row) if isinstance(row, list) else []
+
+
+def _optional_value_at(row: list[object], index: int) -> object:
+    return row[index] if index < len(row) else None

--- a/src/importing/infinitybuilds/_talisman.py
+++ b/src/importing/infinitybuilds/_talisman.py
@@ -22,14 +22,12 @@ def _parse_talisman_gear(value: object) -> list[_GearPiece]:
     for index, charm_id in enumerate(charms if isinstance(charms, list) else []):
         if not isinstance(charm_id, str):
             continue
-        gear.append(
-            {
-                "kind": "talisman",
-                "slot": f"charm{index + 1}",
-                "itemId": charm_id,
-                "affixes": _parse_charm_affixes(raw, index),
-            }
-        )
+        gear.append({
+            "kind": "talisman",
+            "slot": f"charm{index + 1}",
+            "itemId": charm_id,
+            "affixes": _parse_charm_affixes(raw, index),
+        })
     return gear
 
 

--- a/src/importing/infinitybuilds/adapter.py
+++ b/src/importing/infinitybuilds/adapter.py
@@ -15,6 +15,7 @@ from src.importing.filters import (
     match_to_enum,
     update_mingreateraffixcount,
 )
+from src.importing.infinitybuilds._talisman import _charm_set_name
 from src.importing.infinitybuilds.extraction import (
     _canonical_catalog_id,
     _convert_raw_to_affixes,
@@ -31,7 +32,7 @@ from src.importing.infinitybuilds.paragon import (
 )
 from src.importing.pipeline import ExtractedBuild, ImportPipeline, StaticBuildGuideAdapter, Variant
 from src.importing.web import retry_importer
-from src.item import Dataloader, ItemType
+from src.item import Dataloader, ItemRarity, ItemType
 from src.profiles import AspectUniqueFilterModel, CharmFilterModel, ItemFilterModel, SealFilterModel
 
 if TYPE_CHECKING:
@@ -127,7 +128,8 @@ def _import_infinitybuilds(request: ImportRequest, driver: WebDriver | None = No
             if str(variant.get("id") or index) in request.variant_selection
         ]
     # Resolve all variants' gear in a single API call to avoid redundant round trips.
-    resolved = _resolve_gear_data(class_name, [piece for variant in variants for piece in variant["gear"]])
+    variant_gear = [variant["gear"] + variant.get("talisman", []) for variant in variants]
+    resolved = _resolve_gear_data(class_name, [piece for gear in variant_gear for piece in gear])
     paragon_catalog: InfinityBuildsParagonCatalog | None = None
     if request.options.export_paragon:
         try:
@@ -137,8 +139,8 @@ def _import_infinitybuilds(request: ImportRequest, driver: WebDriver | None = No
                 "Could not fetch InfinityBuilds paragon catalog data, skipping paragon export.", exc_info=True
             )
     extracted_variants = []
-    for variant in variants:
-        extracted_variant = _build_variant_for_gear(gear=variant["gear"], resolved=resolved, request=request)
+    for variant, gear in zip(variants, variant_gear, strict=True):
+        extracted_variant = _build_variant_for_gear(gear=gear, resolved=resolved, request=request)
         extracted_variant.name = variant.get("name", "")
         if paragon_catalog is not None:
             extracted_variant.paragon_steps = extract_infinitybuilds_paragon_steps(
@@ -201,31 +203,37 @@ def _build_variant_for_gear(
         )
         if item_type == ItemType.Charm:
             unique_name = item_name if is_unique_like else None
-            if not affixes and not unique_name:
-                LOGGER.warning(f"Skipping {item_name} because it had no supported affixes or unique aspect.")
-                continue
-            charm_filters.append(
-                create_seal_charm_filter(
-                    affixes=affixes,
-                    require_gas=request.options.require_greater_affixes,
-                    model_type=CharmFilterModel,
-                    unique_name=unique_name,
+            set_name = _charm_set_name(item_name)
+            charm_rarity = match_to_enum(ItemRarity, "common" if rarity == "normal" else rarity)
+            if not affixes and not unique_name and not set_name and charm_rarity is None:
+                LOGGER.warning(
+                    f"Skipping {item_name} because it had no supported affixes, unique aspect, set, or rarity."
                 )
+                continue
+            charm_filter = create_seal_charm_filter(
+                affixes=affixes,
+                require_gas=request.options.require_greater_affixes,
+                model_type=CharmFilterModel,
+                unique_name=unique_name,
+                set_name=set_name,
             )
+            charm_filter.rarities = [charm_rarity] if charm_rarity else []
+            charm_filters.append(charm_filter)
             continue
         if item_type == ItemType.HoradricSeal:
             unique_name = item_name if is_unique_like else None
-            if not affixes and not unique_name:
-                LOGGER.warning(f"Skipping {item_name} because it had no supported affixes or unique aspect.")
+            seal_rarity = match_to_enum(ItemRarity, rarity)
+            if not affixes and not unique_name and seal_rarity is None:
+                LOGGER.warning(f"Skipping {item_name} because it had no supported affixes, unique aspect, or rarity.")
                 continue
-            seal_filters.append(
-                create_seal_charm_filter(
-                    affixes=affixes,
-                    require_gas=request.options.require_greater_affixes,
-                    model_type=SealFilterModel,
-                    unique_name=unique_name,
-                )
+            seal_filter = create_seal_charm_filter(
+                affixes=affixes,
+                require_gas=request.options.require_greater_affixes,
+                model_type=SealFilterModel,
+                unique_name=unique_name,
             )
+            seal_filter.rarities = [seal_rarity] if seal_rarity else []
+            seal_filters.append(seal_filter)
             continue
         item_filter = ItemFilterModel()
         item_filter.item_type = [item_type] if item_type else []

--- a/src/importing/infinitybuilds/extraction.py
+++ b/src/importing/infinitybuilds/extraction.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 
 from src.importing.conversion import as_string_keyed_mapping as _as_object
 from src.importing.filters import affix_dict_for_item_type
+from src.importing.infinitybuilds._talisman import _catalog_items_by_id, _parse_talisman_gear
 from src.importing.infinitybuilds.models import _ResolvedGearData
 from src.importing.web import get_with_retry
 from src.item import Affix, AffixType, ItemType
@@ -106,11 +107,7 @@ def _extract_balanced(text: str, start_idx: int, open_ch: str, close_ch: str) ->
 
 
 def _canonical_catalog_id(raw_id: str | None) -> str | None:
-    """Strip extra numeric value from catalog id.
-
-    Some build variants embed gear with an extra numeric instance id spliced into the item/aspect
-    which the catalog returned by the API doesn't have. Strip it before lookups.
-    """
+    """Strip the numeric instance value absent from catalog item and aspect IDs."""
     return CATALOG_ID_INSTANCE_PREFIX.sub(r"\1-", raw_id) if raw_id else raw_id
 
 
@@ -140,7 +137,7 @@ def _resolve_gear_data(class_name: str, gear: Sequence[Mapping[str, object]]) ->
     dataset = _as_object(_as_object(response.json()).get("dataset"))
     gear_data = _as_object(dataset.get("gear"))
     return _ResolvedGearData(
-        items=_catalog_by_id(_parse_catalog_items(gear_data.get("items"))),
+        items=_catalog_items_by_id(_parse_catalog_items(gear_data.get("items"))),
         aspects=_catalog_by_id(_parse_catalog_aspects(gear_data.get("aspects"))),
         affixes=_catalog_by_id(_parse_catalog_affixes(gear_data.get("affixes"))),
     )
@@ -177,7 +174,9 @@ def _convert_raw_to_affixes(
             LOGGER.error(f"Couldn't match {resolved_affix['label']=}")
             continue
         affix_obj = Affix(name=matched_name)
-        if import_greater_affixes and resolved_affix.get("greaterAffixEligible") is True:
+        if import_greater_affixes and raw_affix.get("greater") is True:
+            affix_obj.type = AffixType.greater
+        elif import_greater_affixes and resolved_affix.get("greaterAffixEligible") is True:
             value_range = _as_object(resolved_affix.get("valueRange"))
             max_value = value_range.get("max")
             raw_roll = raw_affix.get("value", 0)
@@ -205,6 +204,9 @@ def _parse_variant_data(value: dict[str, object]) -> _VariantData:
     paragon = value.get("paragon")
     if isinstance(paragon, dict):
         variant["paragon"] = _as_object(paragon)
+    talisman = value.get("talisman")
+    if isinstance(talisman, dict):
+        variant["talisman"] = _parse_talisman_gear(talisman)
     return variant
 
 
@@ -233,6 +235,9 @@ def _parse_raw_affix(value: dict[str, object]) -> _RawAffix:
     swapped = value.get("swapped")
     if isinstance(swapped, bool):
         affix["swapped"] = swapped
+    greater = value.get("greater")
+    if isinstance(greater, bool):
+        affix["greater"] = greater
     raw_value = value.get("value")
     if isinstance(raw_value, (int, float)) and not isinstance(raw_value, bool):
         affix["value"] = raw_value
@@ -247,7 +252,7 @@ def _parse_catalog_items(value: object) -> list[_CatalogItem]:
         if not isinstance(entry_id, str):
             continue
         item: _CatalogItem = {"id": entry_id}
-        for key in ("label", "rarity", "slot"):
+        for key in ("sourceId", "label", "rarity", "slot"):
             item_value = entry_object.get(key)
             if isinstance(item_value, str):
                 item[key] = item_value

--- a/src/importing/infinitybuilds/models.py
+++ b/src/importing/infinitybuilds/models.py
@@ -8,6 +8,7 @@ class _RawAffix(TypedDict, total=False):
     affixId: str
     tempered: bool
     swapped: bool
+    greater: bool
     value: int | float
 
 
@@ -24,6 +25,7 @@ class _VariantData(TypedDict, total=False):
     name: str
     gear: list[_GearPiece]
     paragon: dict[str, object]
+    talisman: list[_GearPiece]
 
 
 class BuildData(TypedDict):
@@ -37,6 +39,7 @@ class _ValueRange(TypedDict, total=False):
 
 class _CatalogItem(TypedDict, total=False):
     id: str
+    sourceId: str
     label: str
     rarity: str
     slot: str

--- a/src/item/filter/engine.py
+++ b/src/item/filter/engine.py
@@ -14,7 +14,6 @@ from src.item.filter.equipment import FilterEquipmentMixin
 from src.item.filter.matching import FilterContext, FilterMatchingMixin
 from src.item.filter.special import FilterSpecialMixin
 from src.item.models import FilterResult, MatchedFilter
-from src.item.sigil_rules import SigilRules
 from src.profiles import ProfileDocumentError, ProfileDocumentStore
 from src.settings import get_settings
 
@@ -243,23 +242,19 @@ class Filter(FilterSpecialMixin, FilterEquipmentMixin, FilterMatchingMixin, Filt
             self.load_files()
         return self.paragon_filters
 
-    @staticmethod
-    def _is_mythic_sigil(item: Item) -> bool:
-        return SigilRules.default().for_item(item).rarity == ItemRarity.Mythic
-
     def _skipped_by_filter_override(self, item: Item) -> bool:
         settings = get_settings().general
         if is_sigil(item.item_type):
-            return not settings.filter_sigils and not self._is_mythic_sigil(item)
+            return not settings.filter_sigils
         if item.item_type == ItemType.Tribute:
-            return not settings.filter_tributes and item.rarity != ItemRarity.Mythic
+            return not settings.filter_tributes
         if item.item_type == ItemType.HoradricSeal:
-            return not settings.filter_seals and item.rarity != ItemRarity.Mythic
+            return not settings.filter_seals
         if item.item_type == ItemType.Charm:
-            return not settings.filter_charms and item.rarity != ItemRarity.Mythic
+            return not settings.filter_charms
         if item.item_type is None or item.power is None:
             return False
-        return not settings.filter_equipment and item.rarity != ItemRarity.Mythic
+        return not settings.filter_equipment
 
     def should_keep(self, item: Item) -> FilterResult:
         if not self.files_loaded or self._did_files_change():

--- a/src/item/filter/engine.py
+++ b/src/item/filter/engine.py
@@ -14,6 +14,7 @@ from src.item.filter.equipment import FilterEquipmentMixin
 from src.item.filter.matching import FilterContext, FilterMatchingMixin
 from src.item.filter.special import FilterSpecialMixin
 from src.item.models import FilterResult, MatchedFilter
+from src.item.sigil_rules import SigilRules
 from src.profiles import ProfileDocumentError, ProfileDocumentStore
 from src.settings import get_settings
 
@@ -242,9 +243,30 @@ class Filter(FilterSpecialMixin, FilterEquipmentMixin, FilterMatchingMixin, Filt
             self.load_files()
         return self.paragon_filters
 
+    @staticmethod
+    def _is_mythic_sigil(item: Item) -> bool:
+        return SigilRules.default().for_item(item).rarity == ItemRarity.Mythic
+
+    def _skipped_by_filter_override(self, item: Item) -> bool:
+        settings = get_settings().general
+        if is_sigil(item.item_type):
+            return not settings.filter_sigils and not self._is_mythic_sigil(item)
+        if item.item_type == ItemType.Tribute:
+            return not settings.filter_tributes and item.rarity != ItemRarity.Mythic
+        if item.item_type == ItemType.HoradricSeal:
+            return not settings.filter_seals and item.rarity != ItemRarity.Mythic
+        if item.item_type == ItemType.Charm:
+            return not settings.filter_charms and item.rarity != ItemRarity.Mythic
+        if item.item_type is None or item.power is None:
+            return False
+        return not settings.filter_equipment and item.rarity != ItemRarity.Mythic
+
     def should_keep(self, item: Item) -> FilterResult:
         if not self.files_loaded or self._did_files_change():
             self.load_files()
+        if self._skipped_by_filter_override(item):
+            LOGGER.debug("%s -- Skipped by loot filter override", item.original_name)
+            return FilterResult(keep=False, matched=[], skipped=True)
         res = FilterResult(keep=False, matched=[])
         if is_sigil(item.item_type):
             return self._check_sigil(item)

--- a/src/item/models.py
+++ b/src/item/models.py
@@ -84,6 +84,7 @@ class MatchedFilter:
 class FilterResult:
     keep: bool
     matched: list[MatchedFilter]
+    skipped: bool = False
 
 
 class ItemJSONEncoder(json.JSONEncoder):

--- a/src/loot/fast.py
+++ b/src/loot/fast.py
@@ -184,7 +184,7 @@ def create_match_text(matches: Iterable[MatchedFilter]) -> list[str]:
 def fast_feedback(item_descr, filter_result) -> tuple[str, str] | None:
     """Return the immediate tooltip feedback for a parsed item and its result."""
     colors = get_filter_colors()
-    if not filter_result.keep:
+    if filter_result.skipped or not filter_result.keep:
         return None
 
     if not filter_result.matched:

--- a/src/loot/filter.py
+++ b/src/loot/filter.py
@@ -71,12 +71,14 @@ def check_items(
                 automation.click_pointer("right")
             continue
 
+        res = Filter().should_keep(item_descr)
+        if res.skipped:
+            continue
+
         num_of_affixed_items_checked += 1
         if item_descr.affixes and all(affix.type == AffixType.greater for affix in item_descr.affixes):
             num_of_items_with_all_ga += 1
 
-        # Check if we want to keep the item
-        res = Filter().should_keep(item_descr)
         matched_any_affixes = len(res.matched) > 0 and len(res.matched[0].matched_affixes) > 0
         matched_profile_legendary_aspect = any(
             match.profile.endswith(f".{ASPECT_UPGRADES_LABEL}") for match in res.matched

--- a/src/loot/filter.py
+++ b/src/loot/filter.py
@@ -71,13 +71,13 @@ def check_items(
                 automation.click_pointer("right")
             continue
 
-        res = Filter().should_keep(item_descr)
-        if res.skipped:
-            continue
-
         num_of_affixed_items_checked += 1
         if item_descr.affixes and all(affix.type == AffixType.greater for affix in item_descr.affixes):
             num_of_items_with_all_ga += 1
+
+        res = Filter().should_keep(item_descr)
+        if res.skipped:
+            continue
 
         matched_any_affixes = len(res.matched) > 0 and len(res.matched[0].matched_affixes) > 0
         matched_profile_legendary_aspect = any(

--- a/src/loot/highlighting_worker.py
+++ b/src/loot/highlighting_worker.py
@@ -160,6 +160,8 @@ class HighlightingWorker:
 
                         if item_descr == self.current_item:
                             res = Filter().should_keep(item_descr)
+                            if res.skipped:
+                                return
                             match = res.keep
 
                             # Adapt colors based on config

--- a/src/settings/__init__.py
+++ b/src/settings/__init__.py
@@ -119,10 +119,14 @@ def get_ui_coordinates() -> UiCoordinates:
     return ResManager()
 
 
-def create_settings_window(*args: object, **kwargs: object) -> object:
+def create_settings_window(
+    parent: object | None = None,
+    theme_changed_callback: Callable[[], None] | None = None,
+    force_maximized: bool = False,
+) -> object:
     from src.settings.window import ConfigWindow  # ruff:ignore[import-outside-top-level]
 
-    return ConfigWindow(*args, **kwargs)
+    return ConfigWindow(parent=parent, theme_changed_callback=theme_changed_callback, force_maximized=force_maximized)
 
 
 def validate_hotkey(value: str) -> str:

--- a/src/settings/models/general.py
+++ b/src/settings/models/general.py
@@ -16,7 +16,9 @@ from src.settings.models.core import (
     _IniBaseModel,
 )
 
-FILTER_OVERRIDE_DESCRIPTION = "When disabled, non-Mythic {category} are left untouched; Mythic items are always kept."
+FILTER_OVERRIDE_DESCRIPTION = (
+    "When disabled, all {category} are skipped, including Mythic items. When enabled, Mythic items are always kept."
+)
 
 
 class GeneralModel(_IniBaseModel):

--- a/src/settings/models/general.py
+++ b/src/settings/models/general.py
@@ -16,6 +16,8 @@ from src.settings.models.core import (
     _IniBaseModel,
 )
 
+FILTER_OVERRIDE_DESCRIPTION = "When disabled, non-Mythic {category} are left untouched; Mythic items are always kept."
+
 
 class GeneralModel(_IniBaseModel):
     @model_validator(mode="before")
@@ -60,6 +62,36 @@ class GeneralModel(_IniBaseModel):
         default=False,
         description="Do not mark ancestral legendaries as junk",
         title="Protective Ancestral Filter",
+        json_schema_extra={CATEGORY_KEY: SettingsCategory.LOOT},
+    )
+    filter_equipment: bool = Field(
+        default=True,
+        description=FILTER_OVERRIDE_DESCRIPTION.format(category="equipment"),
+        title="Filter Equipment",
+        json_schema_extra={CATEGORY_KEY: SettingsCategory.LOOT},
+    )
+    filter_sigils: bool = Field(
+        default=True,
+        description=FILTER_OVERRIDE_DESCRIPTION.format(category="sigils"),
+        title="Filter Sigils",
+        json_schema_extra={CATEGORY_KEY: SettingsCategory.LOOT},
+    )
+    filter_tributes: bool = Field(
+        default=True,
+        description=FILTER_OVERRIDE_DESCRIPTION.format(category="tributes"),
+        title="Filter Tributes",
+        json_schema_extra={CATEGORY_KEY: SettingsCategory.LOOT},
+    )
+    filter_seals: bool = Field(
+        default=True,
+        description=FILTER_OVERRIDE_DESCRIPTION.format(category="seals"),
+        title="Filter Seals",
+        json_schema_extra={CATEGORY_KEY: SettingsCategory.LOOT},
+    )
+    filter_charms: bool = Field(
+        default=True,
+        description=FILTER_OVERRIDE_DESCRIPTION.format(category="charms"),
+        title="Filter Charms",
         json_schema_extra={CATEGORY_KEY: SettingsCategory.LOOT},
     )
     full_dump: bool = Field(

--- a/src/settings/tab_mixin.py
+++ b/src/settings/tab_mixin.py
@@ -235,6 +235,9 @@ class ConfigTabMixin:
             checkbox = CheckmarkCheckBox()
             checkbox.setObjectName("switch")
             checkbox.setChecked(config_value)
+            if config_key in {"filter_equipment", "filter_sigils", "filter_tributes", "filter_seals", "filter_charms"}:
+                description = type(model).model_json_schema()["properties"].get(config_key, {}).get("description", "")
+                checkbox.setToolTip(description)
 
             def on_bool_changed():
                 self._save_setting_value(

--- a/src/settings/window.py
+++ b/src/settings/window.py
@@ -18,7 +18,7 @@ LOGGER = logging.getLogger(__name__)
 class ConfigWindow(QMainWindow):
     """Standalone window for Config/Settings."""
 
-    def __init__(self, parent=None, theme_changed_callback=None):
+    def __init__(self, parent=None, theme_changed_callback=None, force_maximized: bool = False):
         super().__init__(parent)
 
         if ICON_PATH.exists():
@@ -33,7 +33,7 @@ class ConfigWindow(QMainWindow):
         self.resize(self.settings.value("size", QSize(650, 800)))
         self.move(self.settings.value("pos", QPoint(0, 0)))
 
-        if self.settings.value("maximized", "false") == "true":
+        if force_maximized or self.settings.value("maximized", defaultValue=False, type=bool):
             self.showMaximized()
 
         # Create initial config tab

--- a/tests/app/backend_test.py
+++ b/tests/app/backend_test.py
@@ -1,5 +1,8 @@
 import logging
+import sys
 from types import SimpleNamespace
+
+import pytest
 
 import src.app.backend as backend_module
 from src.app.backend import BackendWorker
@@ -18,6 +21,7 @@ def test_backend_worker_finishes_in_gui_only_mode(monkeypatch, caplog) -> None:
     assert "GUI-only mode" in caplog.text
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="The game backend runtime is Windows-only.")
 def test_backend_starts_tts_listener_before_waiting_for_game_window(monkeypatch) -> None:
     calls = []
 

--- a/tests/app/shell_test.py
+++ b/tests/app/shell_test.py
@@ -63,3 +63,27 @@ def test_profile_editor_inherits_main_window_maximized_state(monkeypatch) -> Non
     assert calls == [
         ("editor", shell_module.create_profile_editor_window, {"profile_name": "beta", "force_maximized": True})
     ]
+
+
+def test_settings_window_inherits_main_window_maximized_state(monkeypatch) -> None:
+    window = UnifiedMainWindow.__new__(UnifiedMainWindow)
+    window.isMaximized = lambda: True
+    window.apply_theme = lambda: None
+    calls = []
+    monkeypatch.setattr(
+        window,
+        "_show_singleton_modal",
+        lambda key, window_factory, **kwargs: calls.append((key, window_factory, kwargs)),
+    )
+    monkeypatch.setattr(shell_module, "set_accent_color", lambda _color: None)
+    monkeypatch.setattr(shell_module, "get_filter_colors", lambda: SimpleNamespace(matched="#fff"))
+
+    window.open_settings_dialog()
+
+    assert calls == [
+        (
+            "config",
+            shell_module.create_settings_window,
+            {"theme_changed_callback": window.apply_theme, "force_maximized": True},
+        )
+    ]

--- a/tests/importing/infinitybuilds/_talisman_test.py
+++ b/tests/importing/infinitybuilds/_talisman_test.py
@@ -1,0 +1,37 @@
+from src.importing.infinitybuilds._talisman import _catalog_items_by_id, _charm_set_name, _parse_talisman_gear
+from src.importing.infinitybuilds.models import _CatalogItem
+
+
+def test_talisman_payload_becomes_catalog_gear() -> None:
+    gear = _parse_talisman_gear(
+        {
+            "seal": "item-1128-seal",
+            "charms": [None, "Talisman_Charm_Set_Barb_01_03"],
+            "charmAffixes": [["unused"], ["affix-all-stats", None]],
+            "charmAffixValues": [[None], [100, None]],
+            "charmAffixGreater": [[None], [True, None]],
+        }
+    )
+
+    assert gear == [
+        {"kind": "talisman", "slot": "seal", "itemId": "item-1128-seal"},
+        {
+            "kind": "talisman",
+            "slot": "charm2",
+            "itemId": "Talisman_Charm_Set_Barb_01_03",
+            "affixes": [{"affixId": "affix-all-stats", "value": 100, "greater": True}],
+        },
+    ]
+
+
+def test_catalog_items_can_be_found_by_infinitybuilds_source_id() -> None:
+    item: _CatalogItem = {
+        "id": "item-talisman-charm-set-barb-01-03-itm",
+        "sourceId": "Talisman_Charm_Set_Barb_01_03.itm",
+        "label": "Mlor of Sescheron's Fury",
+    }
+
+    indexed = _catalog_items_by_id([item])
+
+    assert indexed["Talisman_Charm_Set_Barb_01_03"] is item
+    assert _charm_set_name(item["label"]) == "sescherons_fury"

--- a/tests/importing/infinitybuilds/_talisman_test.py
+++ b/tests/importing/infinitybuilds/_talisman_test.py
@@ -1,17 +1,19 @@
+from typing import TYPE_CHECKING
+
 from src.importing.infinitybuilds._talisman import _catalog_items_by_id, _charm_set_name, _parse_talisman_gear
-from src.importing.infinitybuilds.models import _CatalogItem
+
+if TYPE_CHECKING:
+    from src.importing.infinitybuilds.models import _CatalogItem
 
 
 def test_talisman_payload_becomes_catalog_gear() -> None:
-    gear = _parse_talisman_gear(
-        {
-            "seal": "item-1128-seal",
-            "charms": [None, "Talisman_Charm_Set_Barb_01_03"],
-            "charmAffixes": [["unused"], ["affix-all-stats", None]],
-            "charmAffixValues": [[None], [100, None]],
-            "charmAffixGreater": [[None], [True, None]],
-        }
-    )
+    gear = _parse_talisman_gear({
+        "seal": "item-1128-seal",
+        "charms": [None, "Talisman_Charm_Set_Barb_01_03"],
+        "charmAffixes": [["unused"], ["affix-all-stats", None]],
+        "charmAffixValues": [[None], [100, None]],
+        "charmAffixGreater": [[None], [True, None]],
+    })
 
     assert gear == [
         {"kind": "talisman", "slot": "seal", "itemId": "item-1128-seal"},

--- a/tests/importing/infinitybuilds/adapter_test.py
+++ b/tests/importing/infinitybuilds/adapter_test.py
@@ -148,3 +148,82 @@ def test_import_infinitybuilds_saves_one_profile_per_variant_and_resolves_gear_o
     assert get_with_retry.call_count == 1
     assert "itemIds=item-chest-1%2Citem-chest-2" in get_with_retry.call_args[0][0]
     assert profile_store.save_new.call_count == 2
+
+
+def test_import_infinitybuilds_imports_talisman_charms_and_seal(mock_ini_loader, mocker: MockerFixture) -> None:
+    Dataloader()
+    variants = [
+        {
+            "id": "v-1",
+            "name": "Main",
+            "gear": [_gear_piece("chest", "item-chest", ["affix-armor"])],
+            "talisman": {
+                "seal": "item-1128-talisman-seal-qst-skovos-atanos-mephisto-itm",
+                "charms": ["Talisman_Charm_Set_Barb_01_03", "Talisman_Charm_Unique_S05_BSK_Gloves_Unique_Generic_001"],
+                "charmAffixes": [["affix-charm-all-stats", None], [None, None]],
+                "charmAffixValues": [[100, None], [None, None]],
+                "charmAffixGreater": [[False, None], [None, None]],
+            },
+        }
+    ]
+    driver = _ImportDriver(_page_source("barbarian", variants))
+    response = mocker.Mock()
+    response.json.return_value = {
+        "dataset": {
+            "gear": {
+                "items": [
+                    {"id": "item-chest", "label": "Chest", "rarity": "legendary", "slot": "Chest Armor"},
+                    {
+                        "id": "item-talisman-charm-set-barb-01-03-itm",
+                        "sourceId": "Talisman_Charm_Set_Barb_01_03.itm",
+                        "label": "Mlor of Sescheron's Fury",
+                        "rarity": "normal",
+                        "slot": "Charm",
+                    },
+                    {
+                        "id": "item-talisman-charm-unique-s05-bsk-gloves-unique-generic-001-itm",
+                        "sourceId": "Talisman_Charm_Unique_S05_BSK_Gloves_Unique_Generic_001.itm",
+                        "label": "Endurant Faith",
+                        "rarity": "unique",
+                        "slot": "Charm",
+                    },
+                    {
+                        "id": "item-talisman-seal-qst-skovos-atanos-mephisto-itm",
+                        "sourceId": "Talisman_Seal_QST_Skovos_Atanos_Mephisto.itm",
+                        "label": "Legendary Horadric Seal",
+                        "rarity": "legendary",
+                        "slot": "Horadric Seal",
+                    },
+                ],
+                "aspects": [],
+                "affixes": [
+                    {"id": "affix-armor", "label": "Armor", "greaterAffixEligible": False},
+                    {"id": "affix-charm-all-stats", "label": "All Stats", "greaterAffixEligible": False},
+                ],
+            }
+        }
+    }
+    get_with_retry = mocker.patch("src.importing.infinitybuilds.extraction.get_with_retry", return_value=response)
+    profile_store = mocker.Mock()
+    profile_store.save_new.side_effect = lambda **kwargs: SimpleNamespace(file_name=kwargs["file_name"])
+    mocker.patch("src.profiles.ProfileDocumentStore.default", return_value=profile_store)
+
+    result = import_infinitybuilds(
+        request=_request(url="https://infinitybuilds.gg/en/builds/barbarian-example"),
+        driver=typing.cast("WebDriver", driver),
+    )
+
+    assert result is not None
+    profile = result.profile
+    charms = [charm for group in profile.charms for charm in group.root.values()]
+    assert {charm.set[0] for charm in charms if charm.set} == {"sescherons_fury"}
+    assert {charm.unique_aspect[0].name for charm in charms if charm.unique_aspect} == {"endurant_faith"}
+    set_charm = next(charm for charm in charms if charm.set)
+    assert set_charm.affix_pool[0].count[0].name == "all_stats"
+    assert [rarity.value for rarity in set_charm.rarities] == ["common"]
+    seals = [seal for group in profile.seals for seal in group.root.values()]
+    assert len(seals) == 1
+    assert [rarity.value for rarity in seals[0].rarities] == ["legendary"]
+    called_url = get_with_retry.call_args.args[0]
+    assert "Talisman_Charm_Set_Barb_01_03" in called_url
+    assert "item-talisman-seal-qst-skovos-atanos-mephisto-itm" in called_url

--- a/tests/item/filter/conftest.py
+++ b/tests/item/filter/conftest.py
@@ -2,8 +2,12 @@ import importlib
 import json
 import typing
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
+import src.item.filter.engine as engine_module
+import src.item.filter.equipment as equipment_module
+import src.item.filter.special as special_module
 from src.item import Filter
 
 if typing.TYPE_CHECKING:
@@ -35,6 +39,27 @@ def _create_mocked_filter(mocker: MockerFixture) -> Filter:
     filter_obj.files_loaded = True
     mocker.patch.object(filter_obj, "_did_files_change", return_value=False)
     return filter_obj
+
+
+def _patch_override_settings(mocker, **overrides):
+    general = SimpleNamespace(
+        filter_equipment=True,
+        filter_sigils=True,
+        filter_tributes=True,
+        filter_seals=True,
+        filter_charms=True,
+        handle_cosmetics="ignore",
+        keep_aspects="upgrade",
+        handle_uniques="favorite",
+        ignore_escalation_sigils=True,
+    )
+    for key, value in overrides.items():
+        setattr(general, key, value)
+    settings = SimpleNamespace(general=general)
+    mocker.patch.object(engine_module, "get_settings", return_value=settings)
+    mocker.patch.object(equipment_module, "get_settings", return_value=settings)
+    mocker.patch.object(special_module, "get_settings", return_value=settings)
+    return settings
 
 
 def _decode(value: object) -> object:

--- a/tests/item/filter/engine_test.py
+++ b/tests/item/filter/engine_test.py
@@ -13,7 +13,7 @@ from src.profiles import (
 )
 from src.settings import Settings
 
-from .conftest import _create_mocked_filter, filters
+from .conftest import _create_mocked_filter, _patch_override_settings, filters, sigil_jalal, sigil_mythic_fallback
 
 if typing.TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -186,3 +186,85 @@ def test_invalid_profile_edit_emits_one_report_per_file_version(tmp_path, mocker
     test_filter.load_files()
 
     assert len(reports) == 2
+
+
+CASES = (
+    (
+        "filter_equipment",
+        Item(item_type=ItemType.Helm, power=900, rarity=ItemRarity.Rare),
+        False,
+        Item(item_type=ItemType.Helm, power=900, rarity=ItemRarity.Mythic),
+    ),
+    ("filter_sigils", sigil_jalal, True, sigil_mythic_fallback),
+    (
+        "filter_tributes",
+        Item(name="tribute_of_harmony", rarity=ItemRarity.Magic, item_type=ItemType.Tribute),
+        True,
+        Item(name="tribute_of_harmony", rarity=ItemRarity.Mythic, item_type=ItemType.Tribute),
+    ),
+    (
+        "filter_seals",
+        Item(name="seal", rarity=ItemRarity.Rare, item_type=ItemType.HoradricSeal),
+        False,
+        Item(name="seal", rarity=ItemRarity.Mythic, item_type=ItemType.HoradricSeal),
+    ),
+    (
+        "filter_charms",
+        Item(name="charm", rarity=ItemRarity.Rare, item_type=ItemType.Charm),
+        False,
+        Item(name="charm", rarity=ItemRarity.Mythic, item_type=ItemType.Charm),
+    ),
+)
+
+
+@pytest.mark.parametrize(("setting", "item", "enabled_keep", "mythic"), CASES)
+def test_filterable_item_category_override_skips_non_mythics_but_not_mythics(
+    setting, item, enabled_keep, mythic, mocker
+):
+    settings = _patch_override_settings(mocker, **{setting: False})
+    test_filter = _create_mocked_filter(mocker)
+
+    skipped = test_filter.should_keep(item)
+
+    assert skipped.skipped
+    assert not skipped.keep
+    assert skipped.matched == []
+
+    setattr(settings.general, setting, True)
+    enabled = test_filter.should_keep(item)
+
+    assert not enabled.skipped
+    assert enabled.keep is enabled_keep
+
+    setattr(settings.general, setting, False)
+    mythic_result = test_filter.should_keep(mythic)
+
+    assert mythic_result.skipped is False
+    assert mythic_result.keep
+
+
+def test_disabled_sigils_skip_escalation_before_sigil_behavior(mocker):
+    _patch_override_settings(mocker, filter_sigils=False, ignore_escalation_sigils=False)
+    test_filter = _create_mocked_filter(mocker)
+    escalation_sigil = Item(item_type=ItemType.EscalationSigil, name="escalation")
+
+    result = test_filter.should_keep(escalation_sigil)
+
+    assert result.skipped
+    assert result.matched == []
+
+
+def test_disabled_category_still_loads_and_reports_invalid_profiles(tmp_path, mocker):
+    settings = _patch_override_settings(mocker, filter_equipment=False)
+    settings.general.profiles = ["invalid"]
+    settings.user_dir = tmp_path
+    profile_dir = tmp_path / "profiles"
+    profile_dir.mkdir()
+    (profile_dir / "invalid.yaml").write_text("[invalid", encoding="utf-8")
+    test_filter = _create_mocked_filter(mocker)
+    test_filter.files_loaded = False
+
+    result = test_filter.should_keep(Item(item_type=ItemType.Helm, power=900, rarity=ItemRarity.Rare))
+
+    assert result.skipped
+    assert test_filter.load_failures == ("invalid",)

--- a/tests/item/filter/engine_test.py
+++ b/tests/item/filter/engine_test.py
@@ -218,9 +218,7 @@ CASES = (
 
 
 @pytest.mark.parametrize(("setting", "item", "enabled_keep", "mythic"), CASES)
-def test_filterable_item_category_override_skips_non_mythics_but_not_mythics(
-    setting, item, enabled_keep, mythic, mocker
-):
+def test_filterable_item_category_override_skips_all_items_when_disabled(setting, item, enabled_keep, mythic, mocker):
     settings = _patch_override_settings(mocker, **{setting: False})
     test_filter = _create_mocked_filter(mocker)
 
@@ -239,8 +237,15 @@ def test_filterable_item_category_override_skips_non_mythics_but_not_mythics(
     setattr(settings.general, setting, False)
     mythic_result = test_filter.should_keep(mythic)
 
-    assert mythic_result.skipped is False
-    assert mythic_result.keep
+    assert mythic_result.skipped
+    assert not mythic_result.keep
+    assert mythic_result.matched == []
+
+    setattr(settings.general, setting, True)
+    enabled_mythic = test_filter.should_keep(mythic)
+
+    assert not enabled_mythic.skipped
+    assert enabled_mythic.keep
 
 
 def test_disabled_sigils_skip_escalation_before_sigil_behavior(mocker):

--- a/tests/item/filter/equipment_test.py
+++ b/tests/item/filter/equipment_test.py
@@ -3,12 +3,20 @@ import typing
 import pytest
 from natsort import natsorted
 
-from .conftest import _create_mocked_filter, affixes, filters, global_uniques, simple_mythics, uniques_with_affixes
+from src.item import Affix, Item, ItemRarity, ItemType
+
+from .conftest import (
+    _create_mocked_filter,
+    _patch_override_settings,
+    affixes,
+    filters,
+    global_uniques,
+    simple_mythics,
+    uniques_with_affixes,
+)
 
 if typing.TYPE_CHECKING:
     from pytest_mock import MockerFixture
-
-    from src.item import Item
 
 
 @pytest.mark.parametrize(
@@ -47,3 +55,33 @@ def test_mythic_always_kept(_name: str, result: bool, item: Item, mocker: Mocker
     test_filter = _create_mocked_filter(mocker)
     test_filter.global_unique_filters = {filters.always_keep_mythics.name: filters.always_keep_mythics.global_uniques}
     assert test_filter.should_keep(item).keep == result
+
+
+def test_enabled_equipment_keeps_matches_and_rejects_non_matches(mocker: MockerFixture):
+    settings = _patch_override_settings(mocker)
+    test_filter = _create_mocked_filter(mocker)
+    test_filter.affix_filters = {"profile": filters.affix.affixes}
+    matching = Item(
+        item_type=ItemType.Helm,
+        power=725,
+        rarity=ItemRarity.Rare,
+        affixes=[
+            Affix(name="intelligence", value=10),
+            Affix(name="cooldown_reduction", value=10),
+            Affix(name="maximum_life", value=700),
+            Affix(name="total_armor", value=10),
+        ],
+    )
+    non_matching = Item(item_type=ItemType.Helm, power=725, rarity=ItemRarity.Rare)
+
+    enabled_match = test_filter.should_keep(matching)
+    enabled_non_match = test_filter.should_keep(non_matching)
+
+    assert enabled_match.keep
+    assert not enabled_match.skipped
+    assert not enabled_non_match.keep
+    assert not enabled_non_match.skipped
+
+    settings.general.filter_equipment = False
+    assert test_filter.should_keep(matching).skipped
+    assert test_filter.should_keep(non_matching).skipped

--- a/tests/item/filter/special_test.py
+++ b/tests/item/filter/special_test.py
@@ -9,7 +9,10 @@ from src.profiles import SigilPriority, TributeFilterModel
 
 from .conftest import (
     _create_mocked_filter,
+    _patch_override_settings,
+    charms,
     filters,
+    seals,
     sigil_derived_legendary,
     sigil_derived_rare,
     sigil_jalal,
@@ -23,6 +26,55 @@ from .conftest import (
 
 if typing.TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+
+FILTERED_SPECIAL_CASES = (
+    ("filter_sigils", "sigil_filters", {"profile": filters.sigil.sigils}, sigil_jalal, sigil_rare_blacklisted),
+    (
+        "filter_tributes",
+        "tribute_filters",
+        {"profile": TributeFilterModel(name=["tribute_of_harmony"])},
+        Item(name="tribute_of_harmony", item_type=ItemType.Tribute, rarity=ItemRarity.Magic),
+        Item(name="tribute_of_fake", item_type=ItemType.Tribute, rarity=ItemRarity.Magic),
+    ),
+    (
+        "filter_seals",
+        "seal_filters",
+        {"profile": filters.seal_charm.seals},
+        seals[0][2],
+        Item(item_type=ItemType.HoradricSeal, rarity=ItemRarity.Rare),
+    ),
+    (
+        "filter_charms",
+        "charm_filters",
+        {"profile": filters.seal_charm.charms},
+        charms[0][2],
+        Item(item_type=ItemType.Charm, rarity=ItemRarity.Rare),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("setting", "filter_attribute", "profile_filters", "matching", "non_matching"), FILTERED_SPECIAL_CASES
+)
+def test_enabled_special_categories_keep_matches_and_reject_non_matches(
+    setting, filter_attribute, profile_filters, matching, non_matching, mocker
+):
+    settings = _patch_override_settings(mocker)
+    test_filter = _create_mocked_filter(mocker)
+    setattr(test_filter, filter_attribute, profile_filters)
+
+    enabled_match = test_filter.should_keep(matching)
+    enabled_non_match = test_filter.should_keep(non_matching)
+
+    assert enabled_match.keep
+    assert not enabled_match.skipped
+    assert not enabled_non_match.keep
+    assert not enabled_non_match.skipped
+
+    setattr(settings.general, setting, False)
+    assert test_filter.should_keep(matching).skipped
+    assert test_filter.should_keep(non_matching).skipped
 
 
 @pytest.mark.parametrize(("_name", "result", "item"), natsorted(sigils), ids=[name for name, _, _ in natsorted(sigils)])

--- a/tests/item/models_test.py
+++ b/tests/item/models_test.py
@@ -16,3 +16,11 @@ def test_result_and_json_encoder():
     assert result.matched[0].profile == "profile"
     encoded = json.dumps(Item(name="helm", item_type=ItemType.Helm), cls=ItemJSONEncoder)
     assert '"item_type": "helm"' in encoded
+
+
+def test_filter_result_can_represent_a_skipped_item():
+    result = FilterResult(keep=False, matched=[], skipped=True)
+
+    assert result.skipped
+    assert not result.keep
+    assert result.matched == []

--- a/tests/loot/fast_test.py
+++ b/tests/loot/fast_test.py
@@ -58,6 +58,10 @@ def test_fast_mode_preserves_match_details_and_feedback():
     assert fast_feedback(Item(rarity=ItemRarity.Unique), FilterResult(keep=True, matched=[])) == ("Unique", "#23fc5d")
 
 
+def test_fast_mode_has_no_result_for_a_skipped_item():
+    assert fast_feedback(Item(), FilterResult(keep=False, matched=[], skipped=True)) is None
+
+
 def test_fast_mode_omits_redundant_aspect_for_always_kept_mythics():
     assert fast_feedback(
         Item(rarity=ItemRarity.Mythic),

--- a/tests/loot/filter_test.py
+++ b/tests/loot/filter_test.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 if typing.TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
-from src.item import Affix, AffixType, FilterResult, Item, ItemRarity, ItemType, MatchedFilter
+from src.item import Affix, AffixType, FilterResult, Item, ItemRarity, ItemType
 from src.loot import filter as _filter
 from src.loot.filter import check_items
 from src.settings import ItemRefreshType
@@ -48,7 +48,7 @@ def test_skipped_items_trigger_no_actions_or_filter_statistics(monkeypatch, mock
     assert "all greater affixes" not in caplog.text
 
 
-def test_mythic_keep_still_favorites_when_filter_category_is_disabled(monkeypatch, mocker: MockerFixture):
+def test_mythic_items_are_skipped_when_filter_category_is_disabled(monkeypatch, mocker: MockerFixture):
     inventory = mocker.Mock()
     inventory.get_item_slots.return_value = ([SimpleNamespace(is_junk=False, is_fav=False)], [])
     inventory.menu_name = "inventory"
@@ -67,12 +67,10 @@ def test_mythic_keep_still_favorites_when_filter_category_is_disabled(monkeypatc
     monkeypatch.setattr(_filter.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(_filter, "is_ignored_item", lambda _item: False)
     monkeypatch.setattr(
-        _filter,
-        "Filter",
-        lambda: SimpleNamespace(should_keep=lambda _item: FilterResult(True, [MatchedFilter("Mythics always kept")])),
+        _filter, "Filter", lambda: SimpleNamespace(should_keep=lambda _item: FilterResult(False, [], skipped=True))
     )
     favorite = mocker.patch.object(_filter, "mark_as_favorite")
 
     check_items(inventory, ItemRefreshType.no_refresh)
 
-    favorite.assert_called_once_with()
+    favorite.assert_not_called()

--- a/tests/loot/filter_test.py
+++ b/tests/loot/filter_test.py
@@ -1,8 +1,11 @@
+import logging
 import typing
+from types import SimpleNamespace
 
 if typing.TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
+from src.item import Affix, AffixType, FilterResult, Item, ItemRarity, ItemType, MatchedFilter
 from src.loot import filter as _filter
 from src.loot.filter import check_items
 from src.settings import ItemRefreshType
@@ -18,3 +21,58 @@ def test_force_without_filter_only_refreshes_item_status(monkeypatch, mocker: Mo
 
     reset.assert_called_once_with([], inventory)
     inventory.hover_item_with_delay.assert_not_called()
+
+
+def test_skipped_items_trigger_no_actions_or_filter_statistics(monkeypatch, mocker: MockerFixture, caplog):
+    inventory = mocker.Mock()
+    slots = [SimpleNamespace(is_junk=False, is_fav=False) for _ in range(3)]
+    inventory.get_item_slots.return_value = (slots, [])
+    inventory.menu_name = "inventory"
+    item = Item(item_type=ItemType.Helm, power=900, affixes=[Affix(name="armor", type=AffixType.greater)])
+    monkeypatch.setattr(_filter.src.perception, "read_latest_item", lambda: item)
+    monkeypatch.setattr(_filter, "capture", lambda: object())
+    monkeypatch.setattr(_filter.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(_filter, "is_ignored_item", lambda _item: False)
+    monkeypatch.setattr(
+        _filter, "Filter", lambda: SimpleNamespace(should_keep=lambda _item: FilterResult(False, [], True))
+    )
+    actions = [
+        mocker.patch.object(_filter, name) for name in ("mark_as_favorite", "mark_as_junk", "drop_item_from_inventory")
+    ]
+
+    with caplog.at_level(logging.WARNING, logger=_filter.LOGGER.name):
+        check_items(inventory, ItemRefreshType.no_refresh)
+
+    for action in actions:
+        action.assert_not_called()
+    assert "all greater affixes" not in caplog.text
+
+
+def test_mythic_keep_still_favorites_when_filter_category_is_disabled(monkeypatch, mocker: MockerFixture):
+    inventory = mocker.Mock()
+    inventory.get_item_slots.return_value = ([SimpleNamespace(is_junk=False, is_fav=False)], [])
+    inventory.menu_name = "inventory"
+    item = Item(item_type=ItemType.Helm, power=900, rarity=ItemRarity.Mythic)
+    settings = SimpleNamespace(
+        general=SimpleNamespace(
+            filter_equipment=False,
+            mark_as_favorite=True,
+            do_not_junk_ancestral_legendaries=False,
+            auto_use_temper_manuals=False,
+        )
+    )
+    monkeypatch.setattr(_filter, "get_settings", lambda: settings)
+    monkeypatch.setattr(_filter.src.perception, "read_latest_item", lambda: item)
+    monkeypatch.setattr(_filter, "capture", lambda: object())
+    monkeypatch.setattr(_filter.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(_filter, "is_ignored_item", lambda _item: False)
+    monkeypatch.setattr(
+        _filter,
+        "Filter",
+        lambda: SimpleNamespace(should_keep=lambda _item: FilterResult(True, [MatchedFilter("Mythics always kept")])),
+    )
+    favorite = mocker.patch.object(_filter, "mark_as_favorite")
+
+    check_items(inventory, ItemRefreshType.no_refresh)
+
+    favorite.assert_called_once_with()

--- a/tests/loot/filter_test.py
+++ b/tests/loot/filter_test.py
@@ -23,7 +23,7 @@ def test_force_without_filter_only_refreshes_item_status(monkeypatch, mocker: Mo
     inventory.hover_item_with_delay.assert_not_called()
 
 
-def test_skipped_items_trigger_no_actions_or_filter_statistics(monkeypatch, mocker: MockerFixture, caplog):
+def test_skipped_items_trigger_no_actions_but_still_check_advanced_tooltips(monkeypatch, mocker: MockerFixture, caplog):
     inventory = mocker.Mock()
     slots = [SimpleNamespace(is_junk=False, is_fav=False) for _ in range(3)]
     inventory.get_item_slots.return_value = (slots, [])
@@ -45,7 +45,7 @@ def test_skipped_items_trigger_no_actions_or_filter_statistics(monkeypatch, mock
 
     for action in actions:
         action.assert_not_called()
-    assert "all greater affixes" not in caplog.text
+    assert "3 out of 3 non-junk rarity items checked had all greater affixes" in caplog.text
 
 
 def test_mythic_items_are_skipped_when_filter_category_is_disabled(monkeypatch, mocker: MockerFixture):

--- a/tests/loot/highlighting_worker_test.py
+++ b/tests/loot/highlighting_worker_test.py
@@ -1,13 +1,15 @@
 import typing
 from threading import Event
+from types import SimpleNamespace
 
 import pytest
 
 if typing.TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
+import src.loot.highlighting_worker as worker_module
 import src.perception
-from src.item import Item
+from src.item import FilterResult, Item, ItemRarity, ItemType, MatchedFilter
 from src.loot.highlighting_worker import CancellationRequestedError, HighlightingWorker
 
 
@@ -33,3 +35,61 @@ def test_unparsed_tts_does_not_clear_existing_item_overlay(monkeypatch, mocker: 
     worker.on_tts([])
 
     worker.request_clear.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("filter_result", "should_queue_match"),
+    [(FilterResult(False, [], skipped=True), False), (FilterResult(True, [MatchedFilter("Mythic Sigil")]), True)],
+)
+def test_filter_result_queues_only_normal_highlighting_results(
+    monkeypatch, mocker: MockerFixture, filter_result, should_queue_match
+):
+    worker = object.__new__(HighlightingWorker)
+    item = Item(name="helm", item_type=ItemType.Sigil, rarity=ItemRarity.Mythic if should_queue_match else None)
+    worker.current_item = item
+    worker.is_cleared = True
+    worker.clear_when_item_not_selected_thread = None
+    worker.clear_when_item_not_selected_thread_cancel_event = None
+    worker.request_clear = mocker.Mock()
+    worker.request_match_box = mocker.Mock()
+    worker.request_no_match_box = mocker.Mock()
+    worker.request_empty_outline = mocker.Mock()
+    worker.request_codex_upgrade_box = mocker.Mock()
+    worker.possible_centers = worker_module.np.array([[0, 0]])
+    worker.possible_vendor_centers = worker.possible_centers
+
+    detection = SimpleNamespace(found=True, cropped_descr=object(), crop_roi=(0, 0, 10, 10))
+    monkeypatch.setattr(worker_module, "pointer_position", lambda: (0, 0))
+    monkeypatch.setattr(worker_module, "monitor_to_window", lambda position: position)
+    monkeypatch.setattr("src.loot.highlighting_worker.capture", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(worker_module, "find_descr_with_diagnostics", lambda *_args: detection)
+    monkeypatch.setattr(worker_module, "find_descr", lambda *_args: (True, object(), None))
+    monkeypatch.setattr(worker_module, "compare_image_histograms", lambda *_args: 1.0)
+    monkeypatch.setattr(worker_module, "is_ignored_item", lambda _item: False)
+    monkeypatch.setattr(worker_module, "Filter", lambda: SimpleNamespace(should_keep=lambda _item: filter_result))
+    monkeypatch.setattr(worker_module.time, "sleep", lambda _seconds: None)
+
+    def fake_thread(*_args, **_kwargs):
+        return SimpleNamespace(start=lambda: None)
+
+    monkeypatch.setattr(worker_module.threading, "Thread", fake_thread)
+
+    checks = 0
+
+    def stop_after_first_evaluation(_worker, _event):
+        nonlocal checks
+        checks += 1
+        if checks > 5:
+            raise CancellationRequestedError
+
+    monkeypatch.setattr(HighlightingWorker, "check_for_thread_cancellation", stop_after_first_evaluation)
+
+    worker.evaluate_item_and_queue_draw(item, Event())
+
+    if should_queue_match:
+        worker.request_match_box.assert_called_once()
+    else:
+        worker.request_match_box.assert_not_called()
+    worker.request_no_match_box.assert_not_called()
+    worker.request_empty_outline.assert_not_called()
+    worker.request_codex_upgrade_box.assert_not_called()

--- a/tests/settings/loader_test.py
+++ b/tests/settings/loader_test.py
@@ -7,6 +7,37 @@ from src.settings.loader import PARAMS_INI, IniConfigLoader, SettingsLoadError
 
 
 class TestIniConfigLoader:
+    def test_loot_filter_overrides_persist_false_values_across_reload(
+        self, isolated_ini_loader: IniConfigLoader
+    ) -> None:
+        loader = isolated_ini_loader
+        override_keys = ["filter_equipment", "filter_sigils", "filter_tributes", "filter_seals", "filter_charms"]
+
+        for key in override_keys:
+            loader.save_value("general", key, False)
+
+        config_text = (loader.user_dir / PARAMS_INI).read_text(encoding="utf-8")
+        assert all(f"{key} = False" in config_text for key in override_keys)
+
+        loader.load()
+
+        assert all(getattr(loader.general, key) is False for key in override_keys)
+
+    def test_old_settings_file_defaults_missing_loot_filter_overrides_to_true(
+        self, isolated_ini_loader: IniConfigLoader
+    ) -> None:
+        loader = isolated_ini_loader
+        (loader.user_dir / PARAMS_INI).write_text("[general]\nrun_vision_mode_on_startup = false\n", encoding="utf-8")
+
+        loader.load()
+
+        assert loader.general.run_vision_mode_on_startup is False
+        assert loader.general.filter_equipment is True
+        assert loader.general.filter_sigils is True
+        assert loader.general.filter_tributes is True
+        assert loader.general.filter_seals is True
+        assert loader.general.filter_charms is True
+
     def test_invalid_reload_keeps_last_good_values_and_does_not_notify(
         self, isolated_ini_loader: IniConfigLoader
     ) -> None:

--- a/tests/settings/models/general_test.py
+++ b/tests/settings/models/general_test.py
@@ -1,10 +1,31 @@
 import pytest
 from pydantic import ValidationError
 
+from src.settings.models.core import CATEGORY_KEY, SettingsCategory
 from src.settings.models.general import GeneralModel
 
 
 class TestGeneralModel:
+    def test_loot_filter_overrides_default_to_enabled_with_loot_metadata(self) -> None:
+        expected = {
+            "filter_equipment": "Filter Equipment",
+            "filter_sigils": "Filter Sigils",
+            "filter_tributes": "Filter Tributes",
+            "filter_seals": "Filter Seals",
+            "filter_charms": "Filter Charms",
+        }
+
+        model = GeneralModel()
+
+        assert {key: getattr(model, key) for key in expected} == dict.fromkeys(expected, True)
+        for key, title in expected.items():
+            field = GeneralModel.model_fields[key]
+            assert field.title == title
+            assert field.json_schema_extra[CATEGORY_KEY] == SettingsCategory.LOOT
+            assert "non-Mythic" in field.description
+            assert "left untouched" in field.description
+            assert "always kept" in field.description
+
     def test_profiles_empty_entries_are_removed(self) -> None:
         assert GeneralModel(profiles="alpha, , beta,   ,").profiles == ["alpha", "beta"]
 

--- a/tests/settings/models/general_test.py
+++ b/tests/settings/models/general_test.py
@@ -22,8 +22,9 @@ class TestGeneralModel:
             field = GeneralModel.model_fields[key]
             assert field.title == title
             assert field.json_schema_extra[CATEGORY_KEY] == SettingsCategory.LOOT
-            assert "non-Mythic" in field.description
-            assert "left untouched" in field.description
+            assert "all" in field.description
+            assert "skipped" in field.description
+            assert "including Mythic" in field.description
             assert "always kept" in field.description
 
     def test_profiles_empty_entries_are_removed(self) -> None:

--- a/tests/settings/tab_test.py
+++ b/tests/settings/tab_test.py
@@ -9,3 +9,15 @@ def test_config_tab_can_be_constructed(qapp, isolated_ini_loader) -> None:
     tab = ConfigTab()
     assert tab.nav_list.count() > 0
     tab.close()
+
+
+def test_loot_filter_override_switches_explain_the_mythic_exception(qapp, isolated_ini_loader) -> None:
+    tab = ConfigTab()
+
+    for key in ("equipment", "sigils", "tributes", "seals", "charms"):
+        tooltip = tab.model_to_parameter_value_map[f"general.filter_{key}"].toolTip()
+        assert "non-Mythic" in tooltip
+        assert "left untouched" in tooltip
+        assert "always kept" in tooltip
+
+    tab.close()

--- a/tests/settings/tab_test.py
+++ b/tests/settings/tab_test.py
@@ -11,13 +11,14 @@ def test_config_tab_can_be_constructed(qapp, isolated_ini_loader) -> None:
     tab.close()
 
 
-def test_loot_filter_override_switches_explain_the_mythic_exception(qapp, isolated_ini_loader) -> None:
+def test_loot_filter_override_switches_explain_mythic_behavior(qapp, isolated_ini_loader) -> None:
     tab = ConfigTab()
 
     for key in ("equipment", "sigils", "tributes", "seals", "charms"):
         tooltip = tab.model_to_parameter_value_map[f"general.filter_{key}"].toolTip()
-        assert "non-Mythic" in tooltip
-        assert "left untouched" in tooltip
+        assert "all" in tooltip
+        assert "skipped" in tooltip
+        assert "including Mythic" in tooltip
         assert "always kept" in tooltip
 
     tab.close()

--- a/tests/settings/window_test.py
+++ b/tests/settings/window_test.py
@@ -3,6 +3,10 @@ from pathlib import Path
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
+from PyQt6.QtGui import QCloseEvent
+from PyQt6.QtWidgets import QWidget
+
+import src.settings.window as window_module
 from src.settings.window import ICON_PATH, ConfigWindow
 
 
@@ -16,3 +20,85 @@ def test_config_window_can_be_constructed(qapp, isolated_ini_loader) -> None:
     window = ConfigWindow()
     assert window.centralWidget() is not None
     window.close()
+
+
+def test_config_window_restores_maximized_state_from_qsettings(monkeypatch, qapp) -> None:
+    class FakeSettings:
+        def __init__(self, *_args):
+            pass
+
+        def value(self, key, default=None, **kwargs):
+            default = kwargs.get("defaultValue", default)
+            return True if key == "maximized" else default
+
+    class FakeTab(QWidget):
+        def __init__(self, **_kwargs):
+            super().__init__()
+
+    maximized = []
+    monkeypatch.setattr(window_module, "QSettings", FakeSettings)
+    monkeypatch.setattr(window_module, "ConfigTab", FakeTab)
+    monkeypatch.setattr(window_module.QMainWindow, "showMaximized", lambda window: maximized.append(window))
+
+    window = ConfigWindow()
+
+    assert maximized == [window]
+    window.deleteLater()
+
+
+def test_config_window_force_maximized_overrides_saved_state(monkeypatch, qapp) -> None:
+    class FakeSettings:
+        def __init__(self, *_args):
+            pass
+
+        def value(self, key, default=None, **kwargs):
+            default = kwargs.get("defaultValue", default)
+            return False if key == "maximized" else default
+
+    class FakeTab(QWidget):
+        def __init__(self, **_kwargs):
+            super().__init__()
+
+    maximized = []
+    monkeypatch.setattr(window_module, "QSettings", FakeSettings)
+    monkeypatch.setattr(window_module, "ConfigTab", FakeTab)
+    monkeypatch.setattr(window_module.QMainWindow, "showMaximized", lambda window: maximized.append(window))
+
+    window = ConfigWindow(force_maximized=True)
+
+    assert maximized == [window]
+    window.deleteLater()
+
+
+def test_config_window_persists_maximized_state_on_close(monkeypatch, qapp) -> None:
+    class FakeSettings:
+        values = {"maximized": False}
+
+        def __init__(self, *_args):
+            pass
+
+        def value(self, key, default=None, **kwargs):
+            default = kwargs.get("defaultValue", default)
+            return self.values.get(key, default)
+
+        def setValue(self, key, value):  # ruff:ignore[invalid-function-name] - mirrors QSettings API
+            self.values[key] = value
+
+    class FakeTab(QWidget):
+        def __init__(self, **_kwargs):
+            super().__init__()
+
+    maximized = False
+    monkeypatch.setattr(window_module, "QSettings", FakeSettings)
+    monkeypatch.setattr(window_module, "ConfigTab", FakeTab)
+    monkeypatch.setattr(ConfigWindow, "isMaximized", lambda _window: maximized)
+
+    window = ConfigWindow()
+    maximized = True
+    event = QCloseEvent()
+    window.closeEvent(event)
+
+    assert event.isAccepted()
+    assert window.settings.value("maximized") is True
+
+    window.deleteLater()

--- a/uv.lock
+++ b/uv.lock
@@ -1542,7 +1542,7 @@ wheels = [
 
 [[package]]
 name = "seleniumbase"
-version = "4.51.6"
+version = "4.51.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1606,9 +1606,9 @@ dependencies = [
     { name = "wheel" },
     { name = "wsproto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/2d/10c0a8a317845d624c00dd4890be75b08a8ec63ecf95b125c02182126b6b/seleniumbase-4.51.6.tar.gz", hash = "sha256:e2cb5cab56d08a26edf2989ad5277567cbcf6e3c2643c71e9ea2184f0ec3e867", size = 668936, upload-time = "2026-07-22T19:30:18.329Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/92/dac65663cbab903d7d2be831f94587df7fa907ca905c0215ae3a8ab96792/seleniumbase-4.51.8.tar.gz", hash = "sha256:92d71030b9ebca772924b5caed7c44c865a5e149a539b2d733664a4e5bfd05db", size = 670520, upload-time = "2026-07-26T04:51:09.923Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/0d/7ac0a694d5bf1b8d071414764a797c0a4f53500ce7f3f225be7ef65a0f64/seleniumbase-4.51.6-py3-none-any.whl", hash = "sha256:0a9094014e565b4cc0d6f7ec9ea4ac7a59af2d3122f332a37e14dffe62e2d046", size = 674701, upload-time = "2026-07-22T19:30:15.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/7c/6af2efd2f1edda88a0c4d83138586b9014bd155870bad90c4836200eb048/seleniumbase-4.51.8-py3-none-any.whl", hash = "sha256:1c240f6d6fe173c0e51828187a048f5907b1e3ff8c23a4d487f5c65e3730cb41", size = 676369, upload-time = "2026-07-26T04:51:07.017Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -13,11 +13,11 @@ wheels = [
 
 [[package]]
 name = "annotated-types"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
 ]
 
 [[package]]
@@ -1491,27 +1491,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.22"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
-    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]
@@ -1744,11 +1744,11 @@ wheels = [
 
 [[package]]
 name = "types-pywin32"
-version = "312.0.0.20260609"
+version = "312.0.0.20260724"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/e1/a42af4d29cf9a8d9d579bedd022b9f314093bfd9ffe1034ca729acebb30b/types_pywin32-312.0.0.20260609.tar.gz", hash = "sha256:3b6ec4ebf8607ef97563e907e381d8dc40260c3c54ff8819dcea696bd67ca13f", size = 334927, upload-time = "2026-06-09T05:58:27.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/ed/32b91cb4792f25ef30bc87a9aefc3d87867faa804d7fdd5071cef18c2d7c/types_pywin32-312.0.0.20260724.tar.gz", hash = "sha256:0ab44f2eaf24879929a934d4e989c6fbb4aa1df9e44e38eca6d47c680d7c1397", size = 335004, upload-time = "2026-07-24T04:59:09.95Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/eb/008771f4e2c7307b06623ee8bdde12bf9261305f35443e1b943a45a2d5ae/types_pywin32-312.0.0.20260609-py3-none-any.whl", hash = "sha256:713096e5de8202e6a46392e7731653aa99e458f76cebfea0b15d80901f3bb5e1", size = 397302, upload-time = "2026-06-09T05:58:26.339Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/89/15b040c0abf53d88ff3dba292e82038854745a8576cd57fc867a60b9517e/types_pywin32-312.0.0.20260724-py3-none-any.whl", hash = "sha256:00a66a2a8a5ccd18d2ac52798f2d1549e74125f0e3d0665e02a33d03fe6fcfcd", size = 397301, upload-time = "2026-07-24T04:59:08.806Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds persistent category-level loot-filter overrides and expands InfinityBuilds imports with talisman charms, seals, rarity, set, and greater-affix data.
- Propagates skipped filter results through inventory actions, fast feedback, and highlighting.
- Adds settings persistence, UI metadata, and maximized-window behavior.
- Updates documentation, tests, application version, and development dependencies.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no eligible blocking failure remains in this follow-up review.

No blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before the change, Mythics in all five categories remained active and were favorited, and the harness exited with code 1.
- After the change, all 20 category/state traces matched expectations and the harness exited with code 0.
- The harness uses repository item fixtures for representative sigils and runs production filtering and loot-processing code under Xvfb, validating the end-to-end flow in the test harness.

<a href="https://app.greptile.com/trex/runs/16053224/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/item/filter/engine.py | Adds category override checks and represents disabled-category evaluations as skipped results. |
| src/loot/filter.py | Prevents skipped items from producing inventory actions or filtering statistics. |
| src/loot/highlighting_worker.py | Suppresses highlighting output for skipped item evaluations. |
| src/importing/infinitybuilds/_talisman.py | Converts InfinityBuilds talisman payloads and catalog aliases into ordinary gear inputs. |
| src/importing/infinitybuilds/adapter.py | Imports talisman charms and seals with set, rarity, unique, affix, and greater-affix constraints. |
| src/settings/models/general.py | Defines persistent, enabled-by-default filter overrides for each supported item category. |
| src/settings/window.py | Supports forced maximization and restores the saved maximized state as a boolean. |

</details>

<sub>Reviews (3): Last reviewed commit: ["changed priority"](https://github.com/d4lfteam/d4lf/commit/3b84525f73c17381e14a4ef71540bb8467e05e26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46803016)</sub>

<!-- /greptile_comment -->